### PR TITLE
TB updates and fix for pulp and hwloop test issues found in regression

### DIFF
--- a/cv32e40p/env/corev-dv/custom/isa/custom/riscv_custom_instr.sv
+++ b/cv32e40p/env/corev-dv/custom/isa/custom/riscv_custom_instr.sv
@@ -681,6 +681,12 @@ class cv32e40p_instr extends riscv_instr;
       end else begin
         imm_str = $sformatf("%0d", $unsigned(imm[11:0]));
       end
+    end else if (category == SIMD) begin
+      if (imm_type == UIMM) begin
+        imm_str = $sformatf("%0d", $unsigned(imm[5:0]));
+      end else begin
+        imm_str = $sformatf("%0d", $signed(imm[5:0]));
+      end
     end else
     super.update_imm_str();
   endfunction

--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
@@ -385,7 +385,7 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
                                    .instr_label(label_s));  //Gen Outer HWLOOP Instr - 1
 
           reserved_rd.delete(); //no longer need to keep the hwloop1 reserved gprs
-          reserved_rd = {hwloop_avail_regs[0],hwloop_avail_regs[1],hwloop_avail_regs[2]}; //preserve count0 reg for nested loop
+          reserved_rd = {hwloop_avail_regs[0],hwloop_avail_regs[1],hwloop_avail_regs[2]}; //preserve hwloop_0 reg for nested loop
 
           if(!use_setup_inst[1] && !use_setup_inst[0] && setup_l0_before_l1_start) begin
 
@@ -893,7 +893,7 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
       i = 0;
       while (i < num_rand_instr) begin
           //Create and Randomize array for avail_regs each time to ensure randomization
-          avail_regs = new[num_of_avail_regs];
+          avail_regs = new[num_of_avail_regs - reserved_rd.size()];
           randomize_avail_regs();
 
           instr = riscv_instr::type_id::create($sformatf("instr_%0d", i));

--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
@@ -43,11 +43,11 @@
 //Nested HWLOOP random generated instruction structure
 //*******************************************************************************************************************************************
 //<loop1_setup_instructions>  -> using start->end->count for this stream TODO: randomize this order?
-//<Random instructions till Loop START1 label>                  ->  use_setup_inst ? 0 : num_fill_instr_cv_end_to_loop_start_label[1] - 1
+//<Random instructions till Loop START1 label>                  ->  use_setup_inst ? 0 : num_fill_instr_loop_ctrl_to_loop_start[1] - 1
 //START1:
 //    <Random instructions till <loop0_setup_instructions>>     ->  gen_nested_loop ? num_fill_instr_in_loop1_till_loop0_setup : NA
 //    <loop0_setup_instructions>
-//    <Random instructions till Loop START0 label>              ->  use_setup_inst ? 0 : num_fill_instr_cv_end_to_loop_start_label[0] - 1
+//    <Random instructions till Loop START0 label>              ->  use_setup_inst ? 0 : num_fill_instr_loop_ctrl_to_loop_start[0] - 1
 //    START0:
 //           <Random instructions till Loop END0 label>         ->  num_hwloop_instr[0]
 //    END0:
@@ -62,7 +62,7 @@
 //Not-Nested HWLOOP random generated instruction structure
 //*******************************************************************************************************************************************
 //<loop0/1_setup_instructions>  -> using start->end->count for this stream TODO: randomize this order?
-//<Random instructions till Loop START0/1 label>                  ->  use_setup_inst ? 0 : num_fill_instr_cv_end_to_loop_start_label[0/1] - 1
+//<Random instructions till Loop START0/1 label>                  ->  use_setup_inst ? 0 : num_fill_instr_loop_ctrl_to_loop_start[0/1] - 1
 //START0/1:
 //    <Random instructions till Loop END0/1 label>                ->  num_hwloop_instr[0/1]
 //END0/1:
@@ -84,12 +84,12 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
   rand bit[11:0]        hwloop_counti[2];
 
   rand int unsigned     num_hwloop_instr[2];
-  rand int unsigned     num_hwloop_setupi_instr[2];
-  rand int unsigned     num_fill_instr_cv_end_to_loop_start_label[2];
+  rand int unsigned     num_hwloop_ctrl_instr[2];
+  rand int unsigned     num_fill_instr_loop_ctrl_to_loop_start[2];
   rand int unsigned     num_fill_instr_in_loop1_till_loop0_setup;
   rand bit              setup_l0_before_l1_start;
 
-  int unsigned          num_fill_instr_cv_start_to_loop_start_label[2];
+  int unsigned          num_instr_cv_start_to_loop_start_label[2];
   cv32e40p_instr        hwloop_setupi_instr[2];
   cv32e40p_instr        hwloop_setup_instr[2];
   cv32e40p_instr        hwloop_starti_instr[2];
@@ -114,11 +114,11 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
       `uvm_field_sarray_int(hwloop_count, UVM_DEFAULT)
       `uvm_field_sarray_int(hwloop_counti, UVM_DEFAULT)
       `uvm_field_sarray_int(num_hwloop_instr, UVM_DEFAULT)
-      `uvm_field_sarray_int(num_hwloop_setupi_instr, UVM_DEFAULT)
-      `uvm_field_sarray_int(num_fill_instr_cv_end_to_loop_start_label, UVM_DEFAULT)
+      `uvm_field_sarray_int(num_hwloop_ctrl_instr, UVM_DEFAULT)
+      `uvm_field_sarray_int(num_fill_instr_loop_ctrl_to_loop_start, UVM_DEFAULT)
       `uvm_field_int(num_fill_instr_in_loop1_till_loop0_setup, UVM_DEFAULT)
       `uvm_field_int(setup_l0_before_l1_start, UVM_DEFAULT)
-      `uvm_field_sarray_int(num_fill_instr_cv_start_to_loop_start_label, UVM_DEFAULT)
+      `uvm_field_sarray_int(num_instr_cv_start_to_loop_start_label, UVM_DEFAULT)
   `uvm_object_utils_end
 
 //
@@ -148,68 +148,99 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
           hwloop_count[i] inside {[0:200]};//TODO: check 0 is valid
   }
 
-  constraint num_hwloop_setupi_instr_c {
-      solve use_loop_setupi_inst[1] before use_loop_setupi_inst[0];
-      solve use_loop_setupi_inst before num_hwloop_setupi_instr;
-      solve use_setup_inst before num_hwloop_setupi_instr;
-      solve gen_nested_loop before num_hwloop_setupi_instr;
-
-      if(gen_nested_loop && use_setup_inst[1] && use_loop_setupi_inst[1]) { //with setupi only [4:0] uimmS range avail for end label
-          num_hwloop_setupi_instr[1] inside {[6:30]}; //with setupi only [4:0] uimmS range avail for end label
-          num_hwloop_setupi_instr[0] inside {[3:27]}; //TODO:in nested hwloop0 with setupi instr more than 27 instructions will have issue if setupi used for hwloop1?
-      } else if(gen_nested_loop && use_setup_inst[0] && use_loop_setupi_inst[0]) {
-          num_hwloop_setupi_instr[0] inside {[3:30]};
-      } else if( (!gen_nested_loop && use_setup_inst[1] && use_loop_setupi_inst[1]) || (!gen_nested_loop && use_setup_inst[0] && use_loop_setupi_inst[0]) ) {
-          num_hwloop_setupi_instr[0] inside {[3:30]};
-          num_hwloop_setupi_instr[1] inside {[3:30]};
-      }
-  }
-
   constraint num_hwloop_instr_c {
       solve num_hwloop_instr[0] before num_hwloop_instr[1];
-      solve num_hwloop_instr[1] before num_fill_instr_in_loop1_till_loop0_setup, num_fill_instr_cv_end_to_loop_start_label[0];
-      solve use_setup_inst before num_hwloop_instr,num_fill_instr_cv_end_to_loop_start_label,num_fill_instr_in_loop1_till_loop0_setup;
-      solve setup_l0_before_l1_start before num_hwloop_instr,num_fill_instr_cv_end_to_loop_start_label,num_fill_instr_in_loop1_till_loop0_setup, use_setup_inst;
-      solve gen_nested_loop before num_hwloop_instr,num_fill_instr_cv_end_to_loop_start_label,num_fill_instr_in_loop1_till_loop0_setup,setup_l0_before_l1_start,use_setup_inst;
 
-      if (setup_l0_before_l1_start == 1) { use_setup_inst[0] == 0};
+      solve num_hwloop_instr[1] before num_fill_instr_in_loop1_till_loop0_setup,
+                                       num_fill_instr_loop_ctrl_to_loop_start[0];
+
+      solve use_loop_setupi_inst[1] before use_loop_setupi_inst[0];
+
+      solve num_hwloop_ctrl_instr before num_hwloop_instr;
+
+      solve gen_nested_loop, setup_l0_before_l1_start, use_setup_inst before num_hwloop_instr,
+                                                                             num_fill_instr_loop_ctrl_to_loop_start,
+                                                                             num_fill_instr_in_loop1_till_loop0_setup,
+                                                                             num_hwloop_ctrl_instr;
+
+      solve gen_nested_loop, setup_l0_before_l1_start before use_setup_inst,
+                                                             use_loop_setupi_inst;
+
+      solve gen_nested_loop before setup_l0_before_l1_start;
+
+
+      setup_l0_before_l1_start dist {0 := 80, 1 := 20};
+
+      if ((gen_nested_loop == 1) && (setup_l0_before_l1_start == 1)) {
+          use_setup_inst[0] == 0;
+          use_setup_inst[1] == 0;
+          use_loop_setupi_inst[0] == 0;
+          use_loop_setupi_inst[1] == 0;
+      }
+
+      if(use_setup_inst[0]) {
+          num_fill_instr_loop_ctrl_to_loop_start[0] == 0;
+          num_hwloop_ctrl_instr[0] == 1;
+      } else {
+          num_fill_instr_loop_ctrl_to_loop_start[0] inside {[0:7]};
+          num_hwloop_ctrl_instr[0] == 3;
+      }
+
+      if(use_setup_inst[1]) {
+          num_fill_instr_loop_ctrl_to_loop_start[1] == 0;
+          num_hwloop_ctrl_instr[1] == 1;
+      } else {
+          num_fill_instr_loop_ctrl_to_loop_start[1] inside {[0:7]};
+          num_hwloop_ctrl_instr[1] == 3;
+      }
 
       if (gen_nested_loop == 1) {
           if (setup_l0_before_l1_start == 1) {
             num_hwloop_instr[0] inside {[3:97]};
-            num_hwloop_instr[1] >= num_hwloop_instr[0] + 3;
-            num_hwloop_instr[1] <= 100;
-            num_fill_instr_cv_end_to_loop_start_label[0] inside {[1:5]};
-            num_fill_instr_cv_end_to_loop_start_label[1] inside {[1:5]};
+            num_hwloop_instr[1] >= num_hwloop_instr[0] + 1 + 2; // 1 for cv.count0 ; 2 for end of loop req
+            num_hwloop_instr[1] <= 99 + 1; // 1 for cv.count0
             num_fill_instr_in_loop1_till_loop0_setup inside {[0:20]};
-            (num_fill_instr_cv_end_to_loop_start_label[0] + num_fill_instr_in_loop1_till_loop0_setup) <= (num_hwloop_instr[1] - num_hwloop_instr[0] - 2);
+            (num_fill_instr_loop_ctrl_to_loop_start[0] + num_fill_instr_in_loop1_till_loop0_setup) <= (num_hwloop_instr[1] - num_hwloop_instr[0] - 2 - 1); // 1 for cv.count0
           } else {
-            if (use_setup_inst[0]) {
-                num_hwloop_instr[0] inside {[3:97]};
-                num_hwloop_instr[1] >= num_hwloop_instr[0] + 3;
-                num_hwloop_instr[1] <= 100;
-                num_fill_instr_cv_end_to_loop_start_label[0] == 0;
-                num_fill_instr_cv_end_to_loop_start_label[1] inside {[1:5]};
+            if (use_setup_inst[1] && use_loop_setupi_inst[1]) { //with setupi only [4:0] uimmS range avail for end label
+                if(use_setup_inst[0]) {
+                  num_hwloop_instr[0] inside {[3:27]}; //TODO:in nested hwloop0 with setupi instr more than 27 instructions will have issue if setupi used for hwloop1?
+                  num_hwloop_instr[1] >= num_hwloop_instr[0] + 1 + 2; // num_hwloop_ctrl_instr[0] == 1 ; 2 for end of loop req
+                } else {
+                  num_hwloop_instr[0] inside {[3:25]}; //TODO:in nested hwloop0 with setupi instr more than 27 instructions will have issue if setupi used for hwloop1?
+                  num_hwloop_instr[1] >= num_hwloop_instr[0] + 3 + 2; // num_hwloop_ctrl_instr[0] == 3 ; 2 for end of loop req
+                }
+                //num_hwloop_instr[1] inside {[6:30]};
+                num_hwloop_instr[1] <= 30; //with setupi only [4:0] uimmS range avail for end label which is equivalent to 30 hwloop body instructions
+                num_fill_instr_in_loop1_till_loop0_setup inside {[0:5]};
+            } else if(use_setup_inst[0] && use_loop_setupi_inst[0]) {
+                num_hwloop_instr[0] inside {[3:30]};
+                num_hwloop_instr[1] >= num_hwloop_instr[0] + 1 + 2; // num_hwloop_ctrl_instr[0] == 1 ; 2 for end of loop req
+                num_hwloop_instr[1] <= 99 + num_hwloop_ctrl_instr[0];
                 num_fill_instr_in_loop1_till_loop0_setup inside {[0:20]};
-                num_fill_instr_in_loop1_till_loop0_setup <= (num_hwloop_instr[1] - num_hwloop_instr[0] - 3);
             } else {
-                num_hwloop_instr[0] inside {[3:95]};
-                num_hwloop_instr[1] >= num_hwloop_instr[0] + 5;
-                num_hwloop_instr[1] <= 100;
-                num_fill_instr_cv_end_to_loop_start_label[0] inside {[1:5]};
-                num_fill_instr_cv_end_to_loop_start_label[1] inside {[1:5]};
+                num_hwloop_instr[0] inside {[3:97]};
+                num_hwloop_instr[1] >= num_hwloop_instr[0] + num_hwloop_ctrl_instr[0] + 2;
+                num_hwloop_instr[1] <= 99 + num_hwloop_ctrl_instr[0];
                 num_fill_instr_in_loop1_till_loop0_setup inside {[0:20]};
-                (num_fill_instr_cv_end_to_loop_start_label[0] + num_fill_instr_in_loop1_till_loop0_setup) <= (num_hwloop_instr[1] - num_hwloop_instr[0] - 4);
             }
+            (num_fill_instr_loop_ctrl_to_loop_start[0] + num_fill_instr_in_loop1_till_loop0_setup) <= (num_hwloop_instr[1] - num_hwloop_instr[0] - 2 - num_hwloop_ctrl_instr[0]);
           }
       } else {
-          num_hwloop_instr[0] inside {[3:100]};
-          num_hwloop_instr[1] inside {[3:100]};
-          num_fill_instr_cv_end_to_loop_start_label[0] inside {[1:5]};
-          num_fill_instr_cv_end_to_loop_start_label[1] inside {[1:5]};
+          if(use_setup_inst[1] && use_loop_setupi_inst[1]) {
+              num_hwloop_instr[1] inside {[3:30]};
+          } else {
+              num_hwloop_instr[1] inside {[3:100]};
+          }
+          if(use_setup_inst[0] && use_loop_setupi_inst[0]) {
+              num_hwloop_instr[0] inside {[3:30]};
+          } else {
+              num_hwloop_instr[0] inside {[3:100]};
+          }
           num_fill_instr_in_loop1_till_loop0_setup == 0;
       }
   }
+
 
   function new(string name = "cv32e40p_xpulp_hwloop_base_stream");
       super.new(name);
@@ -272,24 +303,15 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
       bit                   set_label_at_next_instr = 0;
 
       riscv_instr           hwloop_instr_list[$];
-      int unsigned          num_rem_hwloop1_instr;
+      int unsigned          num_rem_hwloop1_instr; //indicates num of hwloop_1 body instructions after  hwloop_0 body for nested hwloops
       string                label_s;
       string                start_label_s;
       string                end_label_s;
 
-      num_fill_instr_cv_start_to_loop_start_label[0] = num_fill_instr_cv_end_to_loop_start_label[0] + 1;//TODO: can be randomized?
-      num_fill_instr_cv_start_to_loop_start_label[1] = num_fill_instr_cv_end_to_loop_start_label[1] + 1;//TODO: can be randomized?
+      num_instr_cv_start_to_loop_start_label[0] = num_fill_instr_loop_ctrl_to_loop_start[0] + 2;//TODO: can be randomized?
+      num_instr_cv_start_to_loop_start_label[1] = num_fill_instr_loop_ctrl_to_loop_start[1] + 2;//TODO: can be randomized?
 
       set_label_at_next_instr = 0;
-
-      if(use_setup_inst[1] && use_loop_setupi_inst[1])
-          num_hwloop_instr[1] = num_hwloop_setupi_instr[1];
-
-      if(use_setup_inst[0] && use_loop_setupi_inst[0])
-          num_hwloop_instr[0] = num_hwloop_setupi_instr[0];
-
-      //calc num_rem_hwloop1_instr after final num_hwloop_instr is available
-      num_rem_hwloop1_instr = num_hwloop_instr[1] - (num_hwloop_instr[0] + num_fill_instr_cv_end_to_loop_start_label[0] + num_fill_instr_in_loop1_till_loop0_setup + 2);
 
       //*************************************************************
       //*******************NESTED HWLOOP*****************************
@@ -298,7 +320,25 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
       if(gen_nested_loop) begin  //NESTED HWLOOP
           gen_cv_count0_instr = $urandom();
 
-    
+          //calculate num_rem_hwloop1_instr
+          if(!setup_l0_before_l1_start) begin
+            num_rem_hwloop1_instr = num_hwloop_instr[1] - (num_fill_instr_in_loop1_till_loop0_setup +
+                                                           num_hwloop_ctrl_instr[0] +
+                                                           num_fill_instr_loop_ctrl_to_loop_start[0] +
+                                                           num_hwloop_instr[0]);
+          end
+          else begin
+            num_rem_hwloop1_instr = num_hwloop_instr[1] - (num_fill_instr_in_loop1_till_loop0_setup +
+                                                           1 +
+                                                           num_fill_instr_loop_ctrl_to_loop_start[0] +
+                                                           num_hwloop_instr[0]);
+
+          end
+
+          //Atleast 2 instructions needed between hwloop_0 and hwloop_1 end labels
+          if(num_rem_hwloop1_instr < 2)
+            `uvm_fatal("cv32e40p_xpulp_hwloop_base_stream",$sformatf("num_rem_hwloop1_instr < 2"))
+
           //Initialize GPRs used as RS1 in HWLOOP Instructions
           hwloop_avail_regs = new[6];  //index fixed for this stream from 0:2 for start0,end0,count0=setup0; 3:5 for start1,end1,count1=setup1 respectively
           std::randomize(hwloop_avail_regs) with  {   unique {hwloop_avail_regs};
@@ -362,13 +402,13 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
               reserved_rd.delete(); //no longer need to keep the hwloop reserved gpr except for count0
               reserved_rd = {hwloop_avail_regs[2]}; //preserve count0 reg for nested loop
 
-              num_fill_instr_cv_end_to_loop_start_label[1] = num_fill_instr_cv_end_to_loop_start_label[1] - 2;
+              num_fill_instr_loop_ctrl_to_loop_start[1] = num_fill_instr_loop_ctrl_to_loop_start[1] - 2;
               if(gen_cv_count0_instr)
-                  num_fill_instr_cv_end_to_loop_start_label[1] = num_fill_instr_cv_end_to_loop_start_label[1] - 1;
+                  num_fill_instr_loop_ctrl_to_loop_start[1] = num_fill_instr_loop_ctrl_to_loop_start[1] - 1;
           end
 
           if(!use_setup_inst[1]) begin
-              insert_rand_instr(.num_rand_instr(num_fill_instr_cv_end_to_loop_start_label[1]-1),
+              insert_rand_instr(.num_rand_instr(num_fill_instr_loop_ctrl_to_loop_start[1]),
                                 .no_branch(1),
                                 .no_compressed(0),
                                 .no_fence(0));  //TODO: Fence instr allowed here?
@@ -392,7 +432,6 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
               set_label_at_next_instr = 1; //no fill instr so next instr must have label
           end
 
-
           start_label_s = $sformatf("hwloop0_nested_start_stream%0d",stream_count);
           end_label_s = $sformatf("hwloop0_nested_end_stream%0d",stream_count);
 
@@ -415,20 +454,21 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
 
           set_label_at_next_instr = 0; //reset flag
 
-          reserved_rd.delete(); //no longer need to keep the hwloop reserved gpr except for count0
-          reserved_rd = {hwloop_avail_regs[2]}; //preserve count0 reg for nested loop
+          //reserved_rd = {hwloop_avail_regs[2]}; //preserve count0 reg for nested loop
 
           if(!use_setup_inst[0])
-              insert_rand_instr(num_fill_instr_cv_end_to_loop_start_label[0]-1);
+              insert_rand_instr(num_fill_instr_loop_ctrl_to_loop_start[0]);
 
           //LABEL HWLOOP0_NESTED_START:
           label_s = $sformatf("hwloop0_nested_start_stream%0d",stream_count);
           insert_rand_instr_with_label(label_s,1);
+
           insert_rand_instr(num_hwloop_instr[0]-1);
 
           //LABEL HWLOOP0_NESTED_END:
           label_s = $sformatf("hwloop0_nested_end_stream%0d",stream_count);
           insert_rand_instr_with_label(label_s,1);
+
           insert_rand_instr(num_rem_hwloop1_instr-1);
 
 
@@ -501,9 +541,9 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
                                        .end_lbl_str(end_label_s),
                                        .instr_label(label_s));
 
-              //Insert Random instructions till Loop HWLOOP_START0/1 label ->  use_setup_inst ? 0 : num_fill_instr_cv_end_to_loop_start_label[0/1] - 1
+              //Insert Random instructions till Loop HWLOOP_START0/1 label ->  use_setup_inst ? 0 : num_fill_instr_loop_ctrl_to_loop_start[0/1]
               if(!use_setup_inst[hwloop_L])
-                  insert_rand_instr((num_fill_instr_cv_end_to_loop_start_label[hwloop_L]-1),1,0,0);  // allow compressed instructions here ; TODO: Fence instr allowed here?
+                  insert_rand_instr((num_fill_instr_loop_ctrl_to_loop_start[hwloop_L]),1,0,0);  // allow compressed instructions here ; TODO: Fence instr allowed here?
 
               //LABEL HWLOOP_START0/1:
               insert_rand_instr_with_label(start_label_s,1); // no branch, no compressed, no fence instructions inside hwloop
@@ -619,7 +659,7 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
       hwloop_starti_instr[hwloop_L].hw_loop_label = hwloop_L;
 
       //randomize immediates
-      starti_uimmL = num_fill_instr_cv_start_to_loop_start_label[hwloop_L] + 1;
+      starti_uimmL = num_instr_cv_start_to_loop_start_label[hwloop_L] + 1;
       hwloop_starti_instr[hwloop_L].imm = starti_uimmL;
       hwloop_starti_instr[hwloop_L].extend_imm();
 
@@ -668,8 +708,9 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
       //TODO: check : while using cv_endi there is possiblity of some other instr before loop start
       //thats why using a count for such fill instructions
 
+      //add 1 to imm - for cv.count instuction after cv.endi instr
       //add 1 to imm - End addr of an HWLoop must point to the instr just after the last one of the HWLoop body
-      endi_uimmL = num_fill_instr_cv_end_to_loop_start_label[hwloop_L] + num_hwloop_instr[hwloop_L] + 1;
+      endi_uimmL = 1 + num_fill_instr_loop_ctrl_to_loop_start[hwloop_L] + num_hwloop_instr[hwloop_L] + 1;
 
       hwloop_endi_instr[hwloop_L].imm = endi_uimmL;
       hwloop_endi_instr[hwloop_L].extend_imm();
@@ -830,7 +871,7 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
                                           bit no_fence=1);
 
       riscv_instr instr;
-      int i;
+      int unsigned i;
 
       //use cfg for ebreak
       if(cfg.no_ebreak)
@@ -861,8 +902,10 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
 
           //randomize GPRs for each instruction
           randomize_gpr(instr);
+
           //randomize immediates for each instruction
           randomize_riscv_instr_imm(instr);
+
           instr_list.push_back(instr);
           i++;
       end
@@ -926,11 +969,11 @@ class cv32e40p_xpulp_short_hwloop_stream extends cv32e40p_xpulp_hwloop_base_stre
       `uvm_field_sarray_int(hwloop_count, UVM_DEFAULT)
       `uvm_field_sarray_int(hwloop_counti, UVM_DEFAULT)
       `uvm_field_sarray_int(num_hwloop_instr, UVM_DEFAULT)
-      `uvm_field_sarray_int(num_hwloop_setupi_instr, UVM_DEFAULT)
-      `uvm_field_sarray_int(num_fill_instr_cv_end_to_loop_start_label, UVM_DEFAULT)
+      `uvm_field_sarray_int(num_hwloop_ctrl_instr, UVM_DEFAULT)
+      `uvm_field_sarray_int(num_fill_instr_loop_ctrl_to_loop_start, UVM_DEFAULT)
       `uvm_field_int(num_fill_instr_in_loop1_till_loop0_setup, UVM_DEFAULT)
       `uvm_field_int(setup_l0_before_l1_start, UVM_DEFAULT)
-      `uvm_field_sarray_int(num_fill_instr_cv_start_to_loop_start_label, UVM_DEFAULT)
+      `uvm_field_sarray_int(num_instr_cv_start_to_loop_start_label, UVM_DEFAULT)
   `uvm_object_utils_end
 
   constraint gen_hwloop_count_c {
@@ -946,65 +989,74 @@ class cv32e40p_xpulp_short_hwloop_stream extends cv32e40p_xpulp_hwloop_base_stre
                               [2048:4094] := 50, 4095 := 300};//TODO: check 0 is valid
   }
 
-  constraint num_hwloop_setupi_instr_c {
-      solve use_loop_setupi_inst[1] before use_loop_setupi_inst[0];
-      solve use_loop_setupi_inst before num_hwloop_setupi_instr;
-      solve use_setup_inst before num_hwloop_setupi_instr;
-      solve gen_nested_loop before num_hwloop_setupi_instr;
-
-      if(gen_nested_loop && use_setup_inst[1] && use_loop_setupi_inst[1]) { //with setupi only [4:0] uimmS range avail for end label
-          num_hwloop_setupi_instr[1] inside {[6:15]}; //with setupi only [4:0] uimmS range avail for end label
-          num_hwloop_setupi_instr[0] inside {[3:12]}; //TODO:in nested hwloop0 with setupi instr more than 27 instructions will have issue if setupi used for hwloop1?
-      } else if(gen_nested_loop && use_setup_inst[0] && use_loop_setupi_inst[0]) {
-          num_hwloop_setupi_instr[0] inside {[3:15]};
-      } else if( (!gen_nested_loop && use_setup_inst[1] && use_loop_setupi_inst[1]) || (!gen_nested_loop && use_setup_inst[0] && use_loop_setupi_inst[0]) ) {
-          num_hwloop_setupi_instr[0] inside {[3:15]};
-          num_hwloop_setupi_instr[1] inside {[3:15]};
-      }
-  }
 
   constraint num_hwloop_instr_c {
       solve num_hwloop_instr[0] before num_hwloop_instr[1];
-      solve num_hwloop_instr[1] before num_fill_instr_in_loop1_till_loop0_setup, num_fill_instr_cv_end_to_loop_start_label[0];
-      solve use_setup_inst before num_hwloop_instr,num_fill_instr_cv_end_to_loop_start_label,num_fill_instr_in_loop1_till_loop0_setup;
-      solve setup_l0_before_l1_start before num_hwloop_instr,num_fill_instr_cv_end_to_loop_start_label,num_fill_instr_in_loop1_till_loop0_setup, use_setup_inst;
-      solve gen_nested_loop before num_hwloop_instr,num_fill_instr_cv_end_to_loop_start_label,num_fill_instr_in_loop1_till_loop0_setup,setup_l0_before_l1_start,use_setup_inst;
 
-      if (setup_l0_before_l1_start == 1) { use_setup_inst[0] == 0};
+      solve num_hwloop_instr[1] before num_fill_instr_in_loop1_till_loop0_setup,
+                                       num_fill_instr_loop_ctrl_to_loop_start[0];
+
+      solve use_loop_setupi_inst[1] before use_loop_setupi_inst[0];
+
+      solve num_hwloop_ctrl_instr before num_hwloop_instr;
+
+      solve gen_nested_loop, setup_l0_before_l1_start, use_setup_inst before num_hwloop_instr,
+                                                                             num_fill_instr_loop_ctrl_to_loop_start,
+                                                                             num_fill_instr_in_loop1_till_loop0_setup,
+                                                                             num_hwloop_ctrl_instr;
+
+      solve gen_nested_loop, setup_l0_before_l1_start before use_setup_inst,
+                                                             use_loop_setupi_inst;
+
+      solve gen_nested_loop before setup_l0_before_l1_start;
+
+
+      setup_l0_before_l1_start dist {0 := 80, 1 := 20};
+
+      if ((gen_nested_loop == 1) && (setup_l0_before_l1_start == 1)) {
+          use_setup_inst[0] == 0;
+          use_setup_inst[1] == 0;
+          use_loop_setupi_inst[0] == 0;
+          use_loop_setupi_inst[1] == 0;
+      }
+
+      if(use_setup_inst[0]) {
+          num_fill_instr_loop_ctrl_to_loop_start[0] == 0;
+          num_hwloop_ctrl_instr[0] == 1;
+      } else {
+          num_fill_instr_loop_ctrl_to_loop_start[0] inside {[0:3]};
+          num_hwloop_ctrl_instr[0] == 3;
+      }
+
+      if(use_setup_inst[1]) {
+          num_fill_instr_loop_ctrl_to_loop_start[1] == 0;
+          num_hwloop_ctrl_instr[1] == 1;
+      } else {
+          num_fill_instr_loop_ctrl_to_loop_start[1] inside {[0:3]};
+          num_hwloop_ctrl_instr[1] == 3;
+      }
 
       if (gen_nested_loop == 1) {
           if (setup_l0_before_l1_start == 1) {
             num_hwloop_instr[0] inside {[3:17]};
-            num_hwloop_instr[1] >= num_hwloop_instr[0] + 3;
-            num_hwloop_instr[1] <= 20;
-            num_fill_instr_cv_end_to_loop_start_label[0] inside {[1:2]};
-            num_fill_instr_cv_end_to_loop_start_label[1] inside {[1:2]};
+            num_hwloop_instr[1] >= num_hwloop_instr[0] + 1 + 2; // 1 for cv.count0 ; 2 for end of loop req
+            num_hwloop_instr[1] <= 19 + 1; // 1 for cv.count0
             num_fill_instr_in_loop1_till_loop0_setup inside {[0:5]};
-            (num_fill_instr_cv_end_to_loop_start_label[0] + num_fill_instr_in_loop1_till_loop0_setup) <= (num_hwloop_instr[1] - num_hwloop_instr[0] - 2);
+            (num_fill_instr_loop_ctrl_to_loop_start[0] + num_fill_instr_in_loop1_till_loop0_setup) <= (num_hwloop_instr[1] - num_hwloop_instr[0] - 2 - 1); // 1 for cv.count0
           } else {
-            if (use_setup_inst[0]) {
-              num_hwloop_instr[0] inside {[3:17]};
-              num_hwloop_instr[1] >= num_hwloop_instr[0] + 3;
-              num_hwloop_instr[1] <= 20;
-              num_fill_instr_cv_end_to_loop_start_label[0] == 0;
-              num_fill_instr_cv_end_to_loop_start_label[1] inside {[1:2]};
-              num_fill_instr_in_loop1_till_loop0_setup inside {[0:5]};
-              num_fill_instr_in_loop1_till_loop0_setup <= (num_hwloop_instr[1] - num_hwloop_instr[0] - 3);
+            if (use_setup_inst[1] && use_loop_setupi_inst[1] && ~use_setup_inst[0]) { //with setupi only [4:0] uimmS range avail for end label
+                  num_hwloop_instr[0] inside {[3:15]};
             } else {
-                num_hwloop_instr[0] inside {[3:15]};
-                num_hwloop_instr[1] >= num_hwloop_instr[0] + 5;
-                num_hwloop_instr[1] <= 20;
-                num_fill_instr_cv_end_to_loop_start_label[0] inside {[1:2]};
-                num_fill_instr_cv_end_to_loop_start_label[1] inside {[1:2]};
-                num_fill_instr_in_loop1_till_loop0_setup inside {[0:5]};
-                (num_fill_instr_cv_end_to_loop_start_label[0] + num_fill_instr_in_loop1_till_loop0_setup) <= (num_hwloop_instr[1] - num_hwloop_instr[0] - 4);
+                num_hwloop_instr[0] inside {[3:17]};
             }
+            num_hwloop_instr[1] >= num_hwloop_instr[0] + num_hwloop_ctrl_instr[0] + 2;
+            num_hwloop_instr[1] <= 20;
+            num_fill_instr_in_loop1_till_loop0_setup inside {[0:4]};
+            (num_fill_instr_loop_ctrl_to_loop_start[0] + num_fill_instr_in_loop1_till_loop0_setup) <= (num_hwloop_instr[1] - num_hwloop_instr[0] - 2 - num_hwloop_ctrl_instr[0]);
           }
       } else {
-          num_hwloop_instr[0] inside {[3:20]};
           num_hwloop_instr[1] inside {[3:20]};
-          num_fill_instr_cv_end_to_loop_start_label[0] inside {[1:2]};
-          num_fill_instr_cv_end_to_loop_start_label[1] inside {[1:2]};
+          num_hwloop_instr[0] inside {[3:20]};
           num_fill_instr_in_loop1_till_loop0_setup == 0;
       }
   }
@@ -1042,11 +1094,11 @@ class cv32e40p_xpulp_long_hwloop_stream extends cv32e40p_xpulp_hwloop_base_strea
       `uvm_field_sarray_int(hwloop_count, UVM_DEFAULT)
       `uvm_field_sarray_int(hwloop_counti, UVM_DEFAULT)
       `uvm_field_sarray_int(num_hwloop_instr, UVM_DEFAULT)
-      `uvm_field_sarray_int(num_hwloop_setupi_instr, UVM_DEFAULT)
-      `uvm_field_sarray_int(num_fill_instr_cv_end_to_loop_start_label, UVM_DEFAULT)
+      `uvm_field_sarray_int(num_hwloop_ctrl_instr, UVM_DEFAULT)
+      `uvm_field_sarray_int(num_fill_instr_loop_ctrl_to_loop_start, UVM_DEFAULT)
       `uvm_field_int(num_fill_instr_in_loop1_till_loop0_setup, UVM_DEFAULT)
       `uvm_field_int(setup_l0_before_l1_start, UVM_DEFAULT)
-      `uvm_field_sarray_int(num_fill_instr_cv_start_to_loop_start_label, UVM_DEFAULT)
+      `uvm_field_sarray_int(num_instr_cv_start_to_loop_start_label, UVM_DEFAULT)
   `uvm_object_utils_end
 
   constraint gen_hwloop_count_c {
@@ -1058,65 +1110,84 @@ class cv32e40p_xpulp_long_hwloop_stream extends cv32e40p_xpulp_hwloop_base_strea
           hwloop_count[i] inside {[0:50]};//TODO: check 0 is valid
   }
 
-  constraint num_hwloop_setupi_instr_c {
-      solve use_loop_setupi_inst[1] before use_loop_setupi_inst[0];
-      solve use_loop_setupi_inst before num_hwloop_setupi_instr;
-      solve use_setup_inst before num_hwloop_setupi_instr;
-      solve gen_nested_loop before num_hwloop_setupi_instr;
-
-      if(gen_nested_loop && use_setup_inst[1] && use_loop_setupi_inst[1]) { //with setupi only [4:0] uimmS range avail for end label
-          num_hwloop_setupi_instr[1] inside {[6:30]}; //with setupi only [4:0] uimmS range avail for end label
-          num_hwloop_setupi_instr[0] inside {[3:27]}; //TODO:in nested hwloop0 with setupi instr more than 27 instructions will have issue if setupi used for hwloop1?
-      } else if(gen_nested_loop && use_setup_inst[0] && use_loop_setupi_inst[0]) {
-          num_hwloop_setupi_instr[0] inside {[3:30]};
-      } else if( (!gen_nested_loop && use_setup_inst[1] && use_loop_setupi_inst[1]) || (!gen_nested_loop && use_setup_inst[0] && use_loop_setupi_inst[0]) ) {
-          num_hwloop_setupi_instr[0] inside {[3:30]};
-          num_hwloop_setupi_instr[1] inside {[3:30]};
-      }
-  }
 
   constraint num_hwloop_instr_c {
       solve num_hwloop_instr[0] before num_hwloop_instr[1];
-      solve num_hwloop_instr[1] before num_fill_instr_in_loop1_till_loop0_setup, num_fill_instr_cv_end_to_loop_start_label[0];
-      solve use_setup_inst before num_hwloop_instr,num_fill_instr_cv_end_to_loop_start_label,num_fill_instr_in_loop1_till_loop0_setup;
-      solve setup_l0_before_l1_start before num_hwloop_instr,num_fill_instr_cv_end_to_loop_start_label,num_fill_instr_in_loop1_till_loop0_setup, use_setup_inst;
-      solve gen_nested_loop before num_hwloop_instr,num_fill_instr_cv_end_to_loop_start_label,num_fill_instr_in_loop1_till_loop0_setup,setup_l0_before_l1_start,use_setup_inst;
 
-      if (setup_l0_before_l1_start == 1) { use_setup_inst[0] == 0};
+      solve num_hwloop_instr[1] before num_fill_instr_in_loop1_till_loop0_setup,
+                                       num_fill_instr_loop_ctrl_to_loop_start[0];
+
+      solve use_loop_setupi_inst[1] before use_loop_setupi_inst[0];
+
+      solve num_hwloop_ctrl_instr before num_hwloop_instr;
+
+      solve gen_nested_loop, setup_l0_before_l1_start, use_setup_inst before num_hwloop_instr,
+                                                                             num_fill_instr_loop_ctrl_to_loop_start,
+                                                                             num_fill_instr_in_loop1_till_loop0_setup,
+                                                                             num_hwloop_ctrl_instr;
+
+      solve gen_nested_loop, setup_l0_before_l1_start before use_setup_inst,
+                                                             use_loop_setupi_inst;
+
+      solve gen_nested_loop before setup_l0_before_l1_start;
+
+
+      setup_l0_before_l1_start dist {0 := 80, 1 := 20};
+
+      if ((gen_nested_loop == 1) && (setup_l0_before_l1_start == 1)) {
+          use_setup_inst[0] == 0;
+          use_setup_inst[1] == 0;
+          use_loop_setupi_inst[0] == 0;
+      }
+
+      if (gen_nested_loop == 0) {
+          use_loop_setupi_inst[0] == 0; //we don't want this case again in long hwloop stream
+      }
+
+      use_loop_setupi_inst[1] == 0; //we don't want this case again in long hwloop stream
+
+      if(use_setup_inst[0]) {
+          num_fill_instr_loop_ctrl_to_loop_start[0] == 0;
+          num_hwloop_ctrl_instr[0] == 1;
+      } else {
+          num_fill_instr_loop_ctrl_to_loop_start[0] inside {[0:200]};
+          num_hwloop_ctrl_instr[0] == 3;
+      }
+
+      if(use_setup_inst[1]) {
+          num_fill_instr_loop_ctrl_to_loop_start[1] == 0;
+          num_hwloop_ctrl_instr[1] == 1;
+      } else {
+          //num_fill_instr_loop_ctrl_to_loop_start[1] inside {[0:200]};
+          num_fill_instr_loop_ctrl_to_loop_start[1] == 0; // For this long test non-zero value here is not necessary
+          num_hwloop_ctrl_instr[1] == 3;
+      }
 
       if (gen_nested_loop == 1) {
           if (setup_l0_before_l1_start == 1) {
-            num_hwloop_instr[0] inside {[3:4091]};
-            num_hwloop_instr[1] >= num_hwloop_instr[0] + 3;
-            num_hwloop_instr[1] <= 4094;
-            num_fill_instr_cv_end_to_loop_start_label[0] inside {[1:100]};
-            num_fill_instr_cv_end_to_loop_start_label[1] inside {[1:100]};
-            num_fill_instr_in_loop1_till_loop0_setup inside {[0:400]};
-            (num_fill_instr_cv_end_to_loop_start_label[0] + num_fill_instr_in_loop1_till_loop0_setup) <= (num_hwloop_instr[1] - num_hwloop_instr[0] - 2);
+              num_hwloop_instr[0] inside {[3:4082]};
+              num_hwloop_instr[1] >= num_hwloop_instr[0] + 1 + 2; // 1 for cv.count0 ; 2 for end of loop req
+              num_hwloop_instr[1] <= 4085; // Max can be 4094 only as end label is on instruction after last instr of HWLOOP
+              num_fill_instr_in_loop1_till_loop0_setup inside {[0:800]};
+              (num_fill_instr_loop_ctrl_to_loop_start[0] + num_fill_instr_in_loop1_till_loop0_setup) <= (num_hwloop_instr[1] - num_hwloop_instr[0] - 2 - 1); // 1 for cv.count0
           } else {
-            if (use_setup_inst[0]) {
-              num_hwloop_instr[0] inside {[3:4091]};
-              num_hwloop_instr[1] >= num_hwloop_instr[0] + 3;
-              num_hwloop_instr[1] <= 4094;
-              num_fill_instr_cv_end_to_loop_start_label[0] == 0;
-              num_fill_instr_cv_end_to_loop_start_label[1] inside {[1:100]};
-              num_fill_instr_in_loop1_till_loop0_setup inside {[0:400]};
-              num_fill_instr_in_loop1_till_loop0_setup <= (num_hwloop_instr[1] - num_hwloop_instr[0] - 3);
-            } else {
-                num_hwloop_instr[0] inside {[3:4089]};
-                num_hwloop_instr[1] >= num_hwloop_instr[0] + 5;
-                num_hwloop_instr[1] <= 4094;
-                num_fill_instr_cv_end_to_loop_start_label[0] inside {[1:100]};
-                num_fill_instr_cv_end_to_loop_start_label[1] inside {[1:100]};
-                num_fill_instr_in_loop1_till_loop0_setup inside {[0:400]};
-                (num_fill_instr_cv_end_to_loop_start_label[0] + num_fill_instr_in_loop1_till_loop0_setup) <= (num_hwloop_instr[1] - num_hwloop_instr[0] - 4);
-            }
+              if (use_setup_inst[0]) {
+                  if (use_loop_setupi_inst[0]) {
+                      num_hwloop_instr[0] inside {[3:30]};
+                  } else {
+                      num_hwloop_instr[0] inside {[3:4082]};
+                  }
+              } else {
+                  num_hwloop_instr[0] inside {[3:4080]};
+              }
+              num_hwloop_instr[1] >= num_hwloop_instr[0] + num_hwloop_ctrl_instr[0] + 2; // 2 for end of loop req
+              num_hwloop_instr[1] <= 4085; // Max can be 4094 only as end label is on instruction after last instr of HWLOOP
+              num_fill_instr_in_loop1_till_loop0_setup inside {[0:800]};
+              (num_fill_instr_loop_ctrl_to_loop_start[0] + num_fill_instr_in_loop1_till_loop0_setup) <= (num_hwloop_instr[1] - num_hwloop_instr[0] - 2 - num_hwloop_ctrl_instr[0]);
           }
       } else {
-          num_hwloop_instr[0] inside {[3:4094]}; // Max can be 4094 only as end label is on instruction after last instr of HWLOOP
-          num_hwloop_instr[1] inside {[3:4094]};
-          num_fill_instr_cv_end_to_loop_start_label[0] inside {[1:100]};
-          num_fill_instr_cv_end_to_loop_start_label[1] inside {[1:100]};
+          num_hwloop_instr[1] inside {[3:4085]}; // Max can be 4094 only as end label is on instruction after last instr of HWLOOP
+          num_hwloop_instr[0] inside {[3:4085]}; // Max can be 4094 only as end label is on instruction after last instr of HWLOOP
           num_fill_instr_in_loop1_till_loop0_setup == 0;
       }
   }
@@ -1155,11 +1226,11 @@ class cv32e40p_xpulp_hwloop_isa_stress_stream extends cv32e40p_xpulp_hwloop_base
       `uvm_field_sarray_int(hwloop_count, UVM_DEFAULT)
       `uvm_field_sarray_int(hwloop_counti, UVM_DEFAULT)
       `uvm_field_sarray_int(num_hwloop_instr, UVM_DEFAULT)
-      `uvm_field_sarray_int(num_hwloop_setupi_instr, UVM_DEFAULT)
-      `uvm_field_sarray_int(num_fill_instr_cv_end_to_loop_start_label, UVM_DEFAULT)
+      `uvm_field_sarray_int(num_hwloop_ctrl_instr, UVM_DEFAULT)
+      `uvm_field_sarray_int(num_fill_instr_loop_ctrl_to_loop_start, UVM_DEFAULT)
       `uvm_field_int(num_fill_instr_in_loop1_till_loop0_setup, UVM_DEFAULT)
       `uvm_field_int(setup_l0_before_l1_start, UVM_DEFAULT)
-      `uvm_field_sarray_int(num_fill_instr_cv_start_to_loop_start_label, UVM_DEFAULT)
+      `uvm_field_sarray_int(num_instr_cv_start_to_loop_start_label, UVM_DEFAULT)
       `uvm_field_int(exclude_floating_pt_instr, UVM_DEFAULT)
       `uvm_field_sarray_enum(riscv_instr_category_t,rand_exclude_category, UVM_DEFAULT)
   `uvm_object_utils_end
@@ -1202,7 +1273,7 @@ class cv32e40p_xpulp_hwloop_isa_stress_stream extends cv32e40p_xpulp_hwloop_base
 
       riscv_instr         instr;
       cv32e40p_instr      cv32_instr;
-      int i;
+      int unsigned i;
 
       //use cfg for ebreak
       if(cfg.no_ebreak)

--- a/cv32e40p/sim/ExternalRepos.mk
+++ b/cv32e40p/sim/ExternalRepos.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40p
 CV_CORE_BRANCH ?= dev
-CV_CORE_HASH   ?= 99772238edb4093e99386599b9f3d79f4d125f30
+CV_CORE_HASH   ?= 25907a07dc1e4557141e2bca957f35ce28cf6dad
 CV_CORE_TAG    ?= none
 
 # The CV_CORE_HASH above points to version of the RTL that is newer.

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_imperas_dv_wrap.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_imperas_dv_wrap.sv
@@ -259,25 +259,29 @@ module uvmt_cv32e40p_imperas_dv_wrap
   import rvviApiPkg::*;
   #(
      parameter FPU   = 0,
-     parameter ZFINX = 0
+     parameter ZFINX = 0,
+     parameter SET_IDV_RECONVERGE = 0
     )
 
     (
         rvviTrace  rvvi // RVVI SystemVerilog Interface
     );
 
+    trace2log       idv_trace2log(rvvi);
+
     localparam bit F_REG = FPU & !ZFINX;
+
     trace2api #(
-        .CMP_PC      (1),
-        .CMP_INS     (1),
-        .CMP_GPR     (1),
-        .CMP_FPR     (F_REG),
-        .CMP_VR      (0),
-        .CMP_CSR     (1)
+        .CMP_PC                 (1),
+        .CMP_INS                (1),
+        .CMP_GPR                (1),
+        .CMP_FPR                (F_REG),
+        .CMP_VR                 (0),
+        .CMP_CSR                (1),
+        .ON_MISMATCH_RECONVERGE (SET_IDV_RECONVERGE)
     )
     trace2api(rvvi);
 
-    trace2log       idv_trace2log(rvvi);
     trace2cov       idv_trace2cov(rvvi);
 
     string info_tag = "ImperasDV_wrap";

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb.sv
@@ -103,6 +103,12 @@ module uvmt_cv32e40p_tb;
    parameter int ENV_PARAM_INSTR_DATA_WIDTH  = 32;
    parameter int ENV_PARAM_RAM_ADDR_WIDTH    = 22;
 
+`ifndef IDV_RECONVERGE
+   parameter int SET_IDV_RECONVERGE = 0;
+`else
+   parameter int SET_IDV_RECONVERGE = 1;
+`endif
+
    // Capture regs for test status from Virtual Peripheral in dut_wrap.mem_i
    bit        tp;
    bit        tf;
@@ -506,8 +512,9 @@ module uvmt_cv32e40p_tb;
     `ifndef FORMAL
     `ifdef USE_ISS
       uvmt_cv32e40p_imperas_dv_wrap #(
-        .FPU  (CORE_PARAM_FPU),
-        .ZFINX(CORE_PARAM_ZFINX)
+        .FPU                    (CORE_PARAM_FPU),
+        .ZFINX                  (CORE_PARAM_ZFINX),
+        .SET_IDV_RECONVERGE     (SET_IDV_RECONVERGE)
       ) imperas_dv (rvvi_if);
     `endif
     `endif

--- a/mk/README.md
+++ b/mk/README.md
@@ -392,7 +392,7 @@ If applicable for a simulator, line debugging will be enabled in the compile to 
 
 **make test TEST=hello-world GUI=1**
 
-### Passing run-time arguments to the simulator
+### Passing run-time arguments to the simulator using **USER_RUN_FLAGS**
 
 The Makefiles support a user controllable variable **USER_RUN_FLAGS** which can be used to pass run-time arguments.  Two typical use-cases for this are provided below:
 
@@ -410,6 +410,18 @@ and signals that you want UVM to use your plusarg over any internally configured
 The following will increase the verbosity level to DEBUG.
 
 **make test TEST=hello-world USER_RUN_FLAGS=+UVM_VERBOSITY=UVM_DEBUG**
+
+### Passing run-time arguments to the simulator using **TEST_CFG_FILE**
+
+For a given test, test.yaml file would typically have all the relevant plusargs for that test, but in certain cases there are new features or updates added to TB, or there is a need to run all the tests with a new TB config, say for example a particular bus delay config. This would previously require to either update all existing tests with new plusargs, or add new tests just for this requirement.
+
+Using this **TEST_CFG_FILE** allows us to retain all existing test setup while providing a simple mechanism to run those tests with additional configs, on top of the ones in test.yaml, passed through a separate yaml file provided using variable TEST_CFG_FILE with the make command.
+
+This is different from above **USER_RUN_FLAGS** method, as this would also create a unique directory path, log names, coverage db etc. suffixed with TEST_CFG_FILE name, and hence this mechanism goes beyond the **USER_RUN_FLAGS** method in a sense that it provides a way to run tests through regression scripts as unique tests differentitated from same default TEST by TEST_CFG_FILE. And hence such tests can be also be rerun, for example in case of failing tests from regression report, without the knowledge of CMD line arguments such as the ones passed through USER_RUN_FLAGS mechanism.
+
+Example:
+
+**make gen_corev-dv test TEST=corev_rand_arithmetic_base_test USE_ISS=no CFG=pulp_fpu WAVES=1 SEED=random TEST_CFG_FILE=floating_pt_instr_en**
 
 ### Post-process Waveform Debug
 


### PR DESCRIPTION
This PR updates following:

- Core hash to latest at the time of PR
- add rvviRefMetricGet to solve core-v-verif issue #2015
- Add param for trace2api ON_MISMATCH_RECONVERGE
- Update mk/README to add desc for TEST_CFG_FILE

FIX for simd and hwloop test issues:
-  fix SIMD UIMM case for update_imm_str
- update imm randomization for cv32e40p_inst type
- Fix constraints issues in hwloop tests for setupi instructions: 
  This is done by simplifying constraints and and fix issues with cv.setupi, resereved_rd.
  Add checks to make sure number random generated instructions never underflow due to constraints
 
