### PR TITLE
Fixes for pulp regress list and some constraints updates for hwloop

### DIFF
--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
@@ -402,8 +402,10 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
               reserved_rd.delete(); //no longer need to keep the hwloop reserved gpr except for count0
               reserved_rd = {hwloop_avail_regs[2]}; //preserve count0 reg for nested loop
 
-              num_fill_instr_loop_ctrl_to_loop_start[1] = num_fill_instr_loop_ctrl_to_loop_start[1] - 2;
-              if(gen_cv_count0_instr)
+              if(num_fill_instr_loop_ctrl_to_loop_start[1] >= 2)
+                  num_fill_instr_loop_ctrl_to_loop_start[1] = num_fill_instr_loop_ctrl_to_loop_start[1] - 2;
+
+              if(gen_cv_count0_instr && num_fill_instr_loop_ctrl_to_loop_start[1] >= 1)
                   num_fill_instr_loop_ctrl_to_loop_start[1] = num_fill_instr_loop_ctrl_to_loop_start[1] - 1;
           end
 

--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
@@ -72,6 +72,8 @@
 
 class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
 
+  localparam MAX_HWLOOP_INSTR_GEN = 4095;
+
   rand riscv_reg_t      hwloop_avail_regs[];
   rand bit[1:0]         num_loops_active;
   rand bit              gen_nested_loop; //nested or not-nested hwloop
@@ -892,6 +894,11 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
                  $sformatf("insert_rand_instr- Number of Random instr to generate= %0d",num_rand_instr),
                  UVM_HIGH)
 
+      if(num_rand_instr > MAX_HWLOOP_INSTR_GEN) begin
+          `uvm_fatal("cv32e40p_xpulp_hwloop_base_stream",
+                      $sformatf("Too many hwloop instr. num_rand_instr = %0d",num_rand_instr))
+      end
+
       i = 0;
       while (i < num_rand_instr) begin
           //Create and Randomize array for avail_regs each time to ensure randomization
@@ -1328,6 +1335,11 @@ class cv32e40p_xpulp_hwloop_isa_stress_stream extends cv32e40p_xpulp_hwloop_base
       `uvm_info("cv32e40p_xpulp_hwloop_isa_stress_stream",
                  $sformatf("Insert_rand_instr- Number of Random instr to generate = %0d",num_rand_instr),
                  UVM_HIGH)
+
+      if(num_rand_instr > MAX_HWLOOP_INSTR_GEN) begin
+          `uvm_fatal("cv32e40p_xpulp_hwloop_isa_stress_stream",
+                      $sformatf("Too many hwloop instr. num_rand_instr = %0d",num_rand_instr))
+      end
 
       i = 0;
       while (i < num_rand_instr) begin

--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
@@ -960,6 +960,8 @@ endclass : cv32e40p_xpulp_hwloop_base_stream
 //Increase Loop Count range to excersize upto 4095 (12-bit) uimmL value
 class cv32e40p_xpulp_short_hwloop_stream extends cv32e40p_xpulp_hwloop_base_stream;
 
+  rand bit              loop0_high_count;
+
   `uvm_object_utils_begin(cv32e40p_xpulp_short_hwloop_stream)
       `uvm_field_int(num_loops_active, UVM_DEFAULT)
       `uvm_field_int(gen_nested_loop, UVM_DEFAULT)
@@ -976,19 +978,49 @@ class cv32e40p_xpulp_short_hwloop_stream extends cv32e40p_xpulp_hwloop_base_stre
       `uvm_field_int(num_fill_instr_in_loop1_till_loop0_setup, UVM_DEFAULT)
       `uvm_field_int(setup_l0_before_l1_start, UVM_DEFAULT)
       `uvm_field_sarray_int(num_instr_cv_start_to_loop_start_label, UVM_DEFAULT)
+      `uvm_field_int(loop0_high_count, UVM_DEFAULT)
   `uvm_object_utils_end
 
   constraint gen_hwloop_count_c {
+
+      solve gen_nested_loop, loop0_high_count before hwloop_count, hwloop_counti;
+      solve gen_nested_loop before loop0_high_count;
+
       num_loops_active inside {1};
 
-      foreach(hwloop_counti[i])
-        hwloop_counti[i] dist {[0:400] := 10, [401:1023] := 300, [1024:2047] := 150,
-                               [2048:4095] := 50, 4095 := 300}; //TODO: check 0 is valid
+      if(gen_nested_loop) {
+        if(loop0_high_count) {
+          hwloop_counti[0] dist {[0:400] := 10, [401:1023] := 300, [1024:2047] := 150,
+                                 [2048:4095] := 50, 4095 := 300};
 
-      //TODO: for rs1 32 bit count ?
-      foreach(hwloop_count[i])
-        hwloop_count[i] dist {[0:400] := 10, [401:1023] := 300, [1024:2047] := 150,
-                              [2048:4094] := 50, 4095 := 300};//TODO: check 0 is valid
+          hwloop_count[0] dist {[0:400] := 10, [401:1023] := 300, [1024:2047] := 150,
+                                [2048:4094] := 50, 4095 := 300};
+
+          hwloop_counti[1] inside {[0:5]};
+          hwloop_count[1] inside {[0:5]};
+
+        } else {
+          hwloop_counti[0] inside {[0:5]};
+          hwloop_count[0] inside {[0:5]};
+
+          hwloop_counti[1] dist {[0:400] := 10, [401:1023] := 300, [1024:2047] := 150,
+                                 [2048:4095] := 50, 4095 := 300};
+
+          hwloop_count[1] dist {[0:400] := 10, [401:1023] := 300, [1024:2047] := 150,
+                                [2048:4094] := 50, 4095 := 300};
+        }
+
+
+      } else {
+        foreach(hwloop_counti[i])
+          hwloop_counti[i] dist {[0:400] := 10, [401:1023] := 300, [1024:2047] := 150,
+                                 [2048:4095] := 50, 4095 := 300}; //TODO: check 0 is valid
+
+        //TODO: for rs1 32 bit count ?
+        foreach(hwloop_count[i])
+          hwloop_count[i] dist {[0:400] := 10, [401:1023] := 300, [1024:2047] := 150,
+                                [2048:4094] := 50, 4095 := 300};//TODO: check 0 is valid
+      }
   }
 
 

--- a/cv32e40p/regress/cv32e40p_xpulp_rand_tests.yaml
+++ b/cv32e40p/regress/cv32e40p_xpulp_rand_tests.yaml
@@ -9,61 +9,63 @@ description: Random pulp tests for CV32E40P
 
 # List of builds
 builds:
-  corev-dv:
-    # required: Make the corev-dv infrastructure    
-    cmd: make comp_corev-dv
+  clean_fw:
+    cmd: make clean-bsp clean_test_programs
+    dir: cv32e40p/sim/uvmt
+
+  clean_corev-dv:
+    cmd: make clean_riscv-dv clone_riscv-dv
     dir: cv32e40p/sim/uvmt
     cov: 0
 
-  uvmt_cv32e40p:
-    # required: the make command to create the build
-    cmd: make comp
-    dir: cv32e40p/sim/uvmt
-
   uvmt_cv32e40p_pulp:
-    cmd: make comp
+    cmd: make comp comp_corev-dv
     cfg: pulp
     dir: cv32e40p/sim/uvmt
+    iss: 1
+    cov: 1
 
   uvmt_cv32e40p_pulp_fpu:
-    cmd: make comp
+    cmd: make comp comp_corev-dv
     cfg: pulp_fpu
     dir: cv32e40p/sim/uvmt
+    iss: 1
+    cov: 1
 
   uvmt_cv32e40p_pulp_fpu_1cyclat:
-    cmd: make comp
+    cmd: make comp comp_corev-dv
     cfg: pulp_fpu_1cyclat
     dir: cv32e40p/sim/uvmt
+    iss: 1
+    cov: 1
 
   uvmt_cv32e40p_pulp_fpu_2cyclat:
-    cmd: make comp
+    cmd: make comp comp_corev-dv
     cfg: pulp_fpu_2cyclat
     dir: cv32e40p/sim/uvmt
-
-  uvmt_cv32e40p_pulp_fpu_3cyclat:
-    cmd: make comp
-    cfg: pulp_fpu_3cyclat
-    dir: cv32e40p/sim/uvmt
+    iss: 1
+    cov: 1
 
   uvmt_cv32e40p_pulp_fpu_zfinx:
-    cmd: make comp
+    cmd: make comp comp_corev-dv
     cfg: pulp_fpu_zfinx
     dir: cv32e40p/sim/uvmt
+    iss: 1
+    cov: 1
 
   uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat:
-    cmd: make comp
+    cmd: make comp comp_corev-dv
     cfg: pulp_fpu_zfinx_1cyclat
     dir: cv32e40p/sim/uvmt
+    iss: 1
+    cov: 1
 
   uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat:
-    cmd: make comp
+    cmd: make comp comp_corev-dv
     cfg: pulp_fpu_zfinx_2cyclat
     dir: cv32e40p/sim/uvmt
-
-  uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat:
-    cmd: make comp
-    cfg: pulp_fpu_zfinx_3cyclat
-    dir: cv32e40p/sim/uvmt
+    iss: 1
+    cov: 1
 
 # List of tests
 tests:
@@ -74,15 +76,14 @@ tests:
       - uvmt_cv32e40p_pulp_fpu
       - uvmt_cv32e40p_pulp_fpu_1cyclat
       - uvmt_cv32e40p_pulp_fpu_2cyclat
-      - uvmt_cv32e40p_pulp_fpu_3cyclat
       - uvmt_cv32e40p_pulp_fpu_zfinx
       - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
       - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
-      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_test
     num: 10
     iss: 1
+    cov: 1
 
   corev_rand_pulp_hwloop_test:
     description: hwloop random test
@@ -91,15 +92,14 @@ tests:
       - uvmt_cv32e40p_pulp_fpu
       - uvmt_cv32e40p_pulp_fpu_1cyclat
       - uvmt_cv32e40p_pulp_fpu_2cyclat
-      - uvmt_cv32e40p_pulp_fpu_3cyclat
       - uvmt_cv32e40p_pulp_fpu_zfinx
       - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
       - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
-      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_test
     num: 10
     iss: 1
+    cov: 1
 
   corev_rand_pulp_mac_instr_test:
     description: pulp mac instr random test
@@ -108,15 +108,14 @@ tests:
       - uvmt_cv32e40p_pulp_fpu
       - uvmt_cv32e40p_pulp_fpu_1cyclat
       - uvmt_cv32e40p_pulp_fpu_2cyclat
-      - uvmt_cv32e40p_pulp_fpu_3cyclat
       - uvmt_cv32e40p_pulp_fpu_zfinx
       - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
       - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
-      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_mac_instr_test
     num: 5
     iss: 1
+    cov: 1
 
   corev_rand_pulp_simd_instr_test:
     description: pulp simd instr random test
@@ -125,15 +124,14 @@ tests:
       - uvmt_cv32e40p_pulp_fpu
       - uvmt_cv32e40p_pulp_fpu_1cyclat
       - uvmt_cv32e40p_pulp_fpu_2cyclat
-      - uvmt_cv32e40p_pulp_fpu_3cyclat
       - uvmt_cv32e40p_pulp_fpu_zfinx
       - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
       - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
-      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_simd_instr_test
     num: 5
     iss: 1
+    cov: 1
 
   corev_rand_pulp_hwloop_debug:
     description: hwloop debug random test
@@ -142,12 +140,11 @@ tests:
       - uvmt_cv32e40p_pulp_fpu
       - uvmt_cv32e40p_pulp_fpu_1cyclat
       - uvmt_cv32e40p_pulp_fpu_2cyclat
-      - uvmt_cv32e40p_pulp_fpu_3cyclat
       - uvmt_cv32e40p_pulp_fpu_zfinx
       - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
       - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
-      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug
     num: 5
     iss: 1
+    cov: 1


### PR DESCRIPTION
- Fixes the pulp regress yaml for updating builds and removing 3cyclat cfgs
- Update hwloop constraints for short stream with large loop counts, cases for nested loops. Previously both the loops were getting large counts, hence update is to avoid such cases (to avoid very long run times).
- Added some more checks in hwloops streams to check for long ranges (again to prevent too long run times)