### PR TITLE
Cv32e40p/bsm update fp test for v2 yaml

### DIFF
--- a/bin/templates/regress_rmdb.j2
+++ b/bin/templates/regress_rmdb.j2
@@ -81,7 +81,7 @@
 {% endfor %}
             </members>
             <preScript launch="exec">
-                <command> cd {{build.abs_dir}} &amp;&amp; {{build.cmd}} CV_CORE={{project}} CFG={{build.cfg}} {{toolchain|upper}}=1 SIMULATOR={{build.simulator}} {{regress_macros.cv_results(results)}} {{makeargs}} </command>
+                <command> cd {{build.abs_dir}} &amp;&amp; {{build.cmd}} CV_CORE={{project}} CFG={{build.cfg}} {{toolchain|upper}}=1 SIMULATOR={{build.simulator}} USE_ISS={{regress_macros.yesorno(build.iss)}} COV={{regress_macros.yesorno(build.cov)}} {{regress_macros.cv_results(results)}} {{makeargs}} </command>
             </preScript>
         </runnable>
 

--- a/bin/templates/regress_sh.j2
+++ b/bin/templates/regress_sh.j2
@@ -39,13 +39,23 @@ check_log () {
     log=$1
     simulation_passed="$2"
     test_name=$3
+    pass_cond=0
+    failed=0
 
+    if grep -qi "Errors:\s\+0" ${log}; then
     if grep -q "${simulation_passed}" ${log}; then
-        echo "{{session}}: Test PASSED: ${test_name} Log: ${log}"
-    else
-        echo "{{session}}: Test FAILED: ${test_name} Log: ${log}"
-        failed=1
+      ((pass_cond+=1))
     fi
+    fi
+
+    if [[ ${pass_cond} == 1 ]]; then
+      echo "{{session}}: Test PASSED: ${test_name} Log: ${log}"
+      return 0
+    else
+      echo "{{session}}: Test FAILED: ${test_name} Log: ${log}"
+      failed=1
+    fi
+
 }
 
 incr_test_counts () {
@@ -132,7 +142,7 @@ compliance_diff_log={{t.abs_dir}}/{{results_dir}}/{{cfg}}/{{test_log}}_{{run_ind
 {% endif %}
 {% endif %}
 
-failed=0
+# failed=0
 check_log ${log} "{{t.simulation_passed}}" {{test_log}}
 {% if 'compliance' in t.cmd %}
 check_log ${compliance_diff_log} "All signatures passed" {{test_log}}

--- a/cv32e40p/regress/cv32e40pv2_ci_check.yaml
+++ b/cv32e40p/regress/cv32e40pv2_ci_check.yaml
@@ -44,17 +44,17 @@ builds:
     dir: cv32e40p/sim/uvmt
 
   uvmt_cv32e40p_pulp_fpu_zfinx:
-    cmd: make comp comp_corev-dv GEN_COMPILE_FLAGS="+define+FP_IN_X_REGS"
+    cmd: make comp comp_corev-dv
     cfg: pulp_fpu_zfinx
     dir: cv32e40p/sim/uvmt
 
   uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat:
-    cmd: make comp comp_corev-dv GEN_COMPILE_FLAGS="+define+FP_IN_X_REGS"
+    cmd: make comp comp_corev-dv
     cfg: pulp_fpu_zfinx_1cyclat
     dir: cv32e40p/sim/uvmt
 
   uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat:
-    cmd: make comp comp_corev-dv GEN_COMPILE_FLAGS="+define+FP_IN_X_REGS"
+    cmd: make comp comp_corev-dv
     cfg: pulp_fpu_zfinx_2cyclat
     dir: cv32e40p/sim/uvmt
 

--- a/cv32e40p/regress/cv32e40pv2_fpu.yaml
+++ b/cv32e40p/regress/cv32e40pv2_fpu.yaml
@@ -33,19 +33,19 @@ builds:
 
   # zfinx related tests
   uvmt_cv32e40p_pulp_fpu_zfinx:
-    cmd: make comp comp_corev-dv GEN_COMPILE_FLAGS="+define+FP_IN_X_REGS"
+    cmd: make comp comp_corev-dv
     cfg: pulp_fpu_zfinx
     dir: cv32e40p/sim/uvmt
     iss: 0
     cov: 0
   uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat:
-    cmd: make comp comp_corev-dv GEN_COMPILE_FLAGS="+define+FP_IN_X_REGS"
+    cmd: make comp comp_corev-dv
     cfg: pulp_fpu_zfinx_1cyclat
     dir: cv32e40p/sim/uvmt
     iss: 0
     cov: 0
   uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat:
-    cmd: make comp comp_corev-dv GEN_COMPILE_FLAGS="+define+FP_IN_X_REGS"
+    cmd: make comp comp_corev-dv
     cfg: pulp_fpu_zfinx_2cyclat
     dir: cv32e40p/sim/uvmt
     iss: 0

--- a/cv32e40p/regress/cv32e40pv2_full_covg.yaml
+++ b/cv32e40p/regress/cv32e40pv2_full_covg.yaml
@@ -35,15 +35,15 @@ builds:
     dir: cv32e40p/sim/uvmt
     cfg: pulp_fpu_2cyclat
   uvmt_cv32e40p_pulp_fpu_zfinx:
-    cmd: make comp comp_corev-dv GEN_COMPILE_FLAGS="+define+FP_IN_X_REGS"
+    cmd: make comp comp_corev-dv
     dir: cv32e40p/sim/uvmt
     cfg: pulp_fpu_zfinx
   uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat:
-    cmd: make comp comp_corev-dv GEN_COMPILE_FLAGS="+define+FP_IN_X_REGS"
+    cmd: make comp comp_corev-dv
     dir: cv32e40p/sim/uvmt
     cfg: pulp_fpu_zfinx_1cyclat
   uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat:
-    cmd: make comp comp_corev-dv GEN_COMPILE_FLAGS="+define+FP_IN_X_REGS"
+    cmd: make comp comp_corev-dv
     dir: cv32e40p/sim/uvmt
     cfg: pulp_fpu_zfinx_2cyclat
 

--- a/mk/uvmt/vsim.mk
+++ b/mk/uvmt/vsim.mk
@@ -178,6 +178,7 @@ endif
 else
 VSIM_FLAGS += +DISABLE_OVPSIM
 endif
+
 ifeq ($(call IS_YES,$(TEST_DISABLE_ALL_CSR_CHECKS)),YES)
 VSIM_FLAGS +="+DISABLE_ALL_CSR_CHECKS"
 endif
@@ -264,9 +265,14 @@ endif
 endif
 
 ifeq ($(call IS_YES,$(CHECK_SIM_RESULT)),YES)
-CHECK_SIM_LOG ?= $(abspath $(SIM_RUN_RESULTS))/vsim-$(TEST_RUN_NAME).log
 POST_TEST = \
-	@if grep -q "SIMULATION FAILED" $(CHECK_SIM_LOG); then \
+	@if grep -q "Errors:\s\+0" $(RUN_DIR)/vsim-$(TEST_RUN_NAME).log; then \
+	if grep -q "SIMULATION FAILED" $(RUN_DIR)/vsim-$(TEST_RUN_NAME).log; then \
+		exit 1; \
+	else \
+		exit 0; \
+	fi \
+	else \
 		exit 1; \
 	fi
 endif
@@ -649,7 +655,7 @@ run: $(VSIM_RUN_PREREQ) gen_ovpsim_ic
 			$(CFG_PLUSARGS) \
 			$(TEST_PLUSARGS) \
 			$(TEST_CFG_FILE_PLUSARGS)
-	@echo "* Log: $(RUN_DIR)/vsim-$(VSIM_TEST).log"
+	@echo "* Log: $(RUN_DIR)/vsim-$(TEST_RUN_NAME).log"
 	$(POST_TEST)
 
 

--- a/mk/uvmt/vsim.mk
+++ b/mk/uvmt/vsim.mk
@@ -384,17 +384,14 @@ vopt_corev-dv:
 			$(CV_CORE_LC)_instr_gen_tb_top \
 			-o $(CV_CORE_LC)_instr_gen_tb_top_vopt \
 			-l vopt.log
+	cd $(SIM_COREVDV_RESULTS) && \
+			$(VMAP) work $(SIM_COREVDV_RESULTS)/work;
 
 gen_corev-dv: $(VSIM_COREVDV_SIM_PREREQ)
 	mkdir -p $(SIM_COREVDV_RESULTS)/$(TEST)
 	for (( idx=${GEN_START_INDEX}; idx < $$((${GEN_START_INDEX} + ${GEN_NUM_TESTS})); idx++ )); do \
 		mkdir -p $(SIM_TEST_RESULTS)/$$idx/test_program; \
 	done
-	if [ -f "$(SIM_COREVDV_RESULTS)/$(TEST)/modelsim.ini" ]; then \
-		rm -rf $(SIM_COREVDV_RESULTS)/$(TEST)/modelsim.ini; \
-	fi
-	cd $(SIM_COREVDV_RESULTS)/$(TEST) && \
-		$(VMAP) work $(SIM_COREVDV_RESULTS)/work; \
 	cd  $(SIM_COREVDV_RESULTS)/$(TEST) && \
 		$(VSIM) \
 			$(VSIM_FLAGS) \
@@ -402,7 +399,7 @@ gen_corev-dv: $(VSIM_COREVDV_SIM_PREREQ)
 			$(DPILIB_VSIM_OPT) \
 			+UVM_TESTNAME=$(GEN_UVM_TEST) \
 			-l $(TEST)_$(GEN_START_INDEX)_$(GEN_NUM_TESTS).log \
-			-modelsimini modelsim.ini \
+			-modelsimini $(SIM_COREVDV_RESULTS)/modelsim.ini \
 			+start_idx=$(GEN_START_INDEX) \
 			+num_of_tests=$(GEN_NUM_TESTS) \
 			+asm_file_name_opts=$(TEST) \

--- a/mk/uvmt/vsim.mk
+++ b/mk/uvmt/vsim.mk
@@ -221,7 +221,12 @@ endif
 # Interactive simulation
 ifeq ($(call IS_YES,$(GUI)),YES)
 ifeq ($(call IS_YES,$(ADV_DEBUG)),YES)
-VSIM_FLAGS += -visualizer=+designfile=$(SIM_TEST_RESULTS)/../design.bin
+ifneq ($(TEST_CFG_FILE),)
+test:         VSIM_FLAGS += -visualizer=+designfile=$(SIM_TEST_RESULTS)/../../design.bin
+else
+test:         VSIM_FLAGS += -visualizer=+designfile=$(SIM_TEST_RESULTS)/../design.bin
+endif
+gen_corev-dv: VSIM_FLAGS += -visualizer=+designfile=../design.bin
 else
 VSIM_FLAGS += -gui
 endif


### PR DESCRIPTION
1) Revert changes to fix missing iss and cov 
2) Temporary solution to prevent missing check of common errors in log file (actual parser will be introduced in later stage)
3) Update build cmd field for fpu zfinx tests