### PR TITLE
Cv32e40p/bsm fp udpate testcases 0818

### DIFF
--- a/cv32e40p/env/corev-dv/cv32e40p_instr_base_test.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_instr_base_test.sv
@@ -84,20 +84,6 @@ class cv32e40p_instr_base_test extends corev_instr_base_test;
         end
       endcase
     end // TEST_OVERRIDE_RISCV_INSTR_STREAM
-    if ($value$plusargs("test_override_fp_instr_stream=%s", test_override_fp_instr_stream)) begin : TEST_OVERRIDE_FP_INSTR_STREAM
-      if (test_override_fp_instr_stream != "default") begin
-        `uvm_info(this.type_name, $sformatf("uvm_factory override stream to %s", test_override_fp_instr_stream), UVM_NONE);
-        case (test_override_fp_instr_stream)
-          "fp_n_mixed_instr":                 begin uvm_factory::get().set_type_override_by_type(cv32e40p_float_zfinx_base_instr_stream::get_type(),  cv32e40p_fp_n_mixed_instr_stream::get_type()); end
-          "fp_n_mixed_instr_more_fdiv_fsqrt": begin uvm_factory::get().set_type_override_by_type(cv32e40p_float_zfinx_base_instr_stream::get_type(),  cv32e40p_fp_n_mixed_instr_more_fdiv_fsqrt_stream::get_type()); end
-          "fp_w_special_operands":            begin uvm_factory::get().set_type_override_by_type(cv32e40p_float_zfinx_base_instr_stream::get_type(),  cv32e40p_fp_w_special_operands_instr_stream::get_type()); end
-          "fp_w_prev_rd_as_operand":          begin uvm_factory::get().set_type_override_by_type(cv32e40p_float_zfinx_base_instr_stream::get_type(),  cv32e40p_fp_w_prev_rd_as_operand_instr_stream::get_type()); end
-          "constraint_mc_fp":                 begin uvm_factory::get().set_type_override_by_type(cv32e40p_float_zfinx_base_instr_stream::get_type(),  cv32e40p_constraint_mc_fp_instr_stream::get_type()); end
-          "fp_operand_forwarding":            begin uvm_factory::get().set_type_override_by_type(cv32e40p_float_zfinx_base_instr_stream::get_type(),  cv32e40p_fp_operand_forwarding_instr_stream::get_type()); end
-          "fp_followed_by_csrr":              begin uvm_factory::get().set_type_override_by_type(cv32e40p_float_zfinx_base_instr_stream::get_type(),  cv32e40p_fp_followed_by_csrr_instr_stream::get_type()); end
-        endcase
-      end
-    end // TEST_OVERRIDE_FP_INSTR_STREAM
   endfunction
 
   virtual function void override_instr_sequence();

--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_float_instr_lib_defines.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_float_instr_lib_defines.sv
@@ -168,10 +168,11 @@
       instr_list[$].comment = {instr_list[$].comment, $sformatf(`" [``OPERAND`` - %s - 32'h%8h] `", ``OPERAND``_pattern.name(), ``OPERAND``)};\
     end
 
-  // 22 always exclude list within fp stream
-  `define   EXCLUDE_INSTR_LIST      {JAL, JALR, BEQ, BNE, BLT, BGE, BLTU, BGEU, ECALL, EBREAK, \
-                                     DRET, MRET, URET, SRET, WFI, C_EBREAK, C_BEQZ, C_BNEZ, C_J, C_JAL, \
-                                     C_JR, C_JALR}
+// 22 always exclude list within fp stream; 11 are related to hw-loop
+  `define   EXCLUDE_INSTR_LIST      {JAL,  JALR, BEQ,  BNE,  BLT, BGE,      BLTU,   BGEU,   ECALL, EBREAK, \
+                                     DRET, MRET, URET, SRET, WFI, C_EBREAK, C_BEQZ, C_BNEZ, C_J,   C_JAL, \
+                                     C_JR, C_JALR, \
+                                     CV_START, CV_STARTI, CV_END, CV_ENDI, CV_COUNT, CV_COUNTI, CV_SETUP, CV_SETUPI, CV_ELW, CV_BEQIMM, CV_BNEIMM}
 
   // refer Table 6-1 user manual
   `define   RV32I_INT_COMP_INSTR_LIST   {ADD, ADDI, SUB, LUI, AUIPC, SLL, SLLI, SRL, SRLI, SRA, SRAI, \

--- a/cv32e40p/tests/programs/corev-dv/corev_rand_fp_instr_sanity_test/corev-dv.yaml
+++ b/cv32e40p/tests/programs/corev-dv/corev_rand_fp_instr_sanity_test/corev-dv.yaml
@@ -32,7 +32,6 @@ plusargs: >
     +directed_instr_4=cv32e40p_fp_w_prev_rd_as_operand_instr_stream,1
     +directed_instr_5=cv32e40p_constraint_mc_fp_instr_stream,1
     +directed_instr_6=cv32e40p_fp_operand_forwarding_instr_stream,1
-    # +directed_instr_7=cv32e40p_fp_followed_by_csrr_instr_stream,1
 
 # note:
   # 1) example yaml template for fp test with f_extension


### PR DESCRIPTION
1) Enable Xpulp in FPU test
2) Add random way to clear csr fflags
3) Remove directed test
4) Remove fpu stream override options