### PR TITLE
Update cv32e40p corev-dv tb files

### DIFF
--- a/cv32e40p/env/corev-dv/custom/isa/cv32e40p_riscv_compressed_instr.sv
+++ b/cv32e40p/env/corev-dv/custom/isa/cv32e40p_riscv_compressed_instr.sv
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * Copyright 2023 OpenHW Group
+ * Copyright 2023 Dolphin Design
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+ */
+
+class cv32e40p_riscv_compressed_instr extends riscv_compressed_instr;
+
+  rand riscv_fpr_t fs1;
+  rand riscv_fpr_t fs2;
+  rand riscv_fpr_t fd;
+  rand bit[4:0]  reg_idx_fs2; //FIXME : dd-vaibhavjain
+  rand bit[4:0]  reg_idx_fd; //FIXME : dd-vaibhavjain
+
+  //FIXME: dd-vaibhavjain. Remove after toolchain fix
+  constraint rv32fc_reg_idx_temp_c {
+    if (instr_name == C_FLW) {
+      reg_idx_fd inside {[8:15]};
+    }
+    if (instr_name == C_FSW) {
+      reg_idx_fs2 inside {[8:15]};
+    }
+  }
+
+  constraint rvc_csr_c {
+    //  Registers specified by the three-bit rs1’, rs2’, and rd’
+    if (format inside {CIW_FORMAT, CL_FORMAT, CS_FORMAT, CB_FORMAT, CA_FORMAT}) {
+      if (has_rs1) {
+        rs1 inside {[S0:A5]};
+        fs1 inside {[S0:A5]};
+      }
+      if (has_rs2) {
+        rs2 inside {[S0:A5]};
+        fs2 inside {[S0:A5]};
+      }
+      if (has_rd) {
+        rd inside {[S0:A5]};
+        fd inside {[S0:A5]};
+      }
+    }
+    // C_ADDI16SP is only valid when rd == SP
+    if (instr_name == C_ADDI16SP) {
+      rd  == SP;
+    }
+    if (instr_name inside {C_JR, C_JALR}) {
+      rs2 == ZERO;
+      rs1 != ZERO;
+    }
+  }
+
+  `uvm_object_utils(cv32e40p_riscv_compressed_instr)
+
+  function new(string name = "");
+    super.new(name);
+    fs1 = FS0;
+    fs2 = FS0;
+    fd  = FS0;
+  endfunction : new
+
+  virtual function void set_imm_len();
+    if (format inside {CI_FORMAT, CSS_FORMAT}) begin
+      imm_len = 6;
+    end else if (format inside {CL_FORMAT, CS_FORMAT}) begin
+      imm_len = 5;
+    end else if (format inside {CJ_FORMAT}) begin
+      imm_len = 11;
+    end else if (format inside {CB_FORMAT}) begin
+      if (instr_name == C_ANDI) begin
+        imm_len = 6;
+      end else begin
+        imm_len = 7;
+      end
+    end else if (format inside {CB_FORMAT, CIW_FORMAT}) begin
+      imm_len = 8;
+    end
+    if (instr_name inside {C_SQ, C_LQ, C_LQSP, C_SQSP, C_ADDI16SP}) begin
+      imm_align = 4;
+    end else if (instr_name inside {C_SD, C_LD, C_LDSP, C_SDSP}) begin
+      imm_align = 3;
+    end else if (instr_name inside {C_SW, C_LW, C_LWSP, C_SWSP, C_ADDI4SPN, C_FSW, C_FLW, C_FLWSP, C_FSWSP}) begin
+      imm_align = 2;
+    end else if (instr_name inside {C_LUI}) begin
+      imm_align = 12;
+    end else if (instr_name inside {C_J, C_JAL, C_BNEZ, C_BEQZ}) begin
+      imm_align = 1;
+    end
+  endfunction : set_imm_len
+
+  // Convert the instruction to assembly code
+  virtual function string convert2asm(string prefix = "");
+    string asm_str;
+    asm_str = format_string(get_instr_name(), MAX_INSTR_STR_LEN);
+
+    std::randomize(reg_idx_fs2) with { if (instr_name == C_FSW) {
+                                         reg_idx_fs2 inside {[8:15]};
+                                       }
+                                     };  //FIXME : dd-vaibhavjain
+
+    std::randomize(reg_idx_fd) with { if (instr_name == C_FLW) {
+                                        reg_idx_fd inside {[8:15]};
+                                      }
+                                    };  //FIXME : dd-vaibhavjain
+
+
+    if (category != SYSTEM) begin
+      case(format)
+        CI_FORMAT, CIW_FORMAT:
+          if (instr_name == C_NOP)
+            asm_str = "c.nop";
+          else if (instr_name == C_ADDI16SP)
+            asm_str = $sformatf("%0ssp, %0s", asm_str, get_imm());
+          else if (instr_name == C_ADDI4SPN)
+            asm_str = $sformatf("%0s%0s, sp, %0s", asm_str, rd.name(), get_imm());
+          else if (instr_name inside {C_LDSP, C_LWSP, C_LQSP})
+            asm_str = $sformatf("%0s%0s, %0s(sp)", asm_str, rd.name(), get_imm());
+          else if (instr_name inside {C_FLWSP})
+            //asm_str = $sformatf("%0s%0s, %0s(sp)", asm_str, fd.name(), get_imm());
+            asm_str = $sformatf("%0s f%0d, %0s(sp)", asm_str, reg_idx_fd, get_imm());  //FIXME : dd-vaibhavjain. revert temp wrd after toolchain fix
+          else
+            asm_str = $sformatf("%0s%0s, %0s", asm_str, rd.name(), get_imm());
+        CL_FORMAT:
+          if (instr_name == C_FLW)
+            //asm_str = $sformatf("%0s%0s, %0s(%0s)", asm_str, fd.name(), get_imm(), rs1.name());
+            asm_str = $sformatf("%0s f%0d, %0s(%0s)", asm_str, reg_idx_fd, get_imm(), rs1.name());  //FIXME : dd-vaibhavjain. revert temp wrd after toolchain fix
+          else
+            asm_str = $sformatf("%0s%0s, %0s(%0s)", asm_str, rd.name(), get_imm(), rs1.name());
+        CS_FORMAT:
+          if (category == STORE)
+            if (instr_name == C_FSW)
+              //asm_str = $sformatf("%0s%0s, %0s(%0s)", asm_str, fs2.name(), get_imm(), rs1.name());
+              asm_str = $sformatf("%0s f%0d, %0s(%0s)", asm_str, reg_idx_fs2, get_imm(), rs1.name());  //FIXME : dd-vaibhavjain. revert temp wrd after toolchain fix
+            else
+              asm_str = $sformatf("%0s%0s, %0s(%0s)", asm_str, rs2.name(), get_imm(), rs1.name());
+          else
+            asm_str = $sformatf("%0s%0s, %0s", asm_str, rs1.name(), rs2.name());
+        CA_FORMAT:
+          asm_str = $sformatf("%0s%0s, %0s", asm_str, rd.name(), rs2.name());
+        CB_FORMAT:
+          asm_str = $sformatf("%0s%0s, %0s", asm_str, rs1.name(), get_imm());
+        CSS_FORMAT:
+          if (category == STORE)
+            if (instr_name == C_FSWSP)
+              //asm_str = $sformatf("%0s%0s, %0s(sp)", asm_str, fs2.name(), get_imm());
+              asm_str = $sformatf("%0s f%0d, %0s(sp)", asm_str, reg_idx_fs2, get_imm()); //FIXME : dd-vaibhavjain. revert temp wrd after toolchain fix
+            else
+              asm_str = $sformatf("%0s%0s, %0s(sp)", asm_str, rs2.name(), get_imm());
+          else
+            asm_str = $sformatf("%0s%0s, %0s", asm_str, rs2.name(), get_imm());
+        CR_FORMAT:
+          if (instr_name inside {C_JR, C_JALR}) begin
+            asm_str = $sformatf("%0s%0s", asm_str, rs1.name());
+          end else begin
+            asm_str = $sformatf("%0s%0s, %0s", asm_str, rd.name(), rs2.name());
+          end
+        CJ_FORMAT:
+          asm_str = $sformatf("%0s%0s", asm_str, get_imm());
+        default: `uvm_info(`gfn, $sformatf("Unsupported format %0s", format.name()), UVM_LOW)
+      endcase
+    end else begin
+      // For EBREAK,C.EBREAK, making sure pc+4 is a valid instruction boundary
+      // This is needed to resume execution from epc+4 after ebreak handling
+      if (instr_name == C_EBREAK) begin
+        asm_str = "c.ebreak;c.nop;";
+      end
+    end
+    if (comment != "")
+      asm_str = {asm_str, " #",comment};
+    return asm_str.tolower();
+  endfunction : convert2asm
+ 
+endclass : cv32e40p_riscv_compressed_instr

--- a/cv32e40p/env/corev-dv/custom/riscv_defines.svh
+++ b/cv32e40p/env/corev-dv/custom/riscv_defines.svh
@@ -91,7 +91,7 @@
 
 // Floating point compressed instruction
 `define DEFINE_FC_INSTR(instr_n, instr_format, instr_category, instr_group, imm_tp = IMM)  \
-  class riscv_``instr_n``_instr extends riscv_compressed_instr;  \
+  class riscv_``instr_n``_instr extends cv32e40p_riscv_compressed_instr;  \
     `INSTR_BODY(instr_n, instr_format, instr_category, instr_group, imm_tp)
 
 // Vector arithmetic instruction

--- a/cv32e40p/env/corev-dv/custom/riscv_instr_pkg.sv
+++ b/cv32e40p/env/corev-dv/custom/riscv_instr_pkg.sv
@@ -1197,7 +1197,7 @@ package riscv_instr_pkg;
   parameter int DATA_WIDTH  = 32;
 
   // Parameters for output assembly program formatting
-  parameter int MAX_INSTR_STR_LEN = 13;
+  parameter int MAX_INSTR_STR_LEN = 21;
   parameter int MAX_PULP_INSTR_STR_LEN = 20;
 
   parameter int LABEL_STR_LEN     = 18;
@@ -1413,6 +1413,7 @@ package riscv_instr_pkg;
   `include "isa/riscv_fp_in_x_regs_instr.sv"
   `include "isa/riscv_vector_instr.sv"
   `include "isa/riscv_compressed_instr.sv"
+  `include "isa/cv32e40p_riscv_compressed_instr.sv"
   `include "isa/rv32a_instr.sv"
   `include "isa/rv32c_instr.sv"
   `include "isa/rv32dc_instr.sv"

--- a/cv32e40p/env/corev-dv/cv32e40p_instr_gen_config.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_instr_gen_config.sv
@@ -45,6 +45,10 @@ class cv32e40p_instr_gen_config extends riscv_instr_gen_config;
   // Config to specify number of rand_directed_instr_* passed in test plusargs
   int test_rand_directed_instr_stream_num = 1;
 
+  rand int num_zfinx_reserved_reg;
+
+  rand riscv_reg_t       zfinx_reserved_gpr[];
+
   constraint dp_c {
     // Debug pointer may not be the return address, stack pointer, nor thread pointer
     if (!gen_debug_section) {
@@ -87,13 +91,33 @@ class cv32e40p_instr_gen_config extends riscv_instr_gen_config;
     }
   }
 
+  constraint num_zfinx_reserved_reg_c {
+    num_zfinx_reserved_reg inside {[5:12]};
+  }
+
+  constraint zfinx_reserved_gpr_c {
+    solve num_zfinx_reserved_reg before zfinx_reserved_gpr;
+    if (RV32ZFINX inside {riscv_instr_pkg::supported_isa}) {
+      zfinx_reserved_gpr.size() == num_zfinx_reserved_reg;
+      unique {zfinx_reserved_gpr};
+      foreach(zfinx_reserved_gpr[i]) {
+        !(zfinx_reserved_gpr[i] inside {ZERO, RA, SP, GP, TP});
+      }
+
+    }
+  }
+
   `uvm_object_utils_begin(cv32e40p_instr_gen_config)
     `uvm_field_enum(mtvec_mode_t, mtvec_mode, UVM_DEFAULT)
     `uvm_field_int(knob_zero_fast_intr_handlers, UVM_DEFAULT)
     `uvm_field_enum(riscv_reg_t, dp, UVM_DEFAULT)
     `uvm_field_enum(riscv_reg_t, scratch_reg, UVM_DEFAULT)
     `uvm_field_int(enable_fast_interrupt_handler, UVM_DEFAULT)
-    `uvm_field_int(use_fast_intr_handler, UVM_DEFAULT)    
+    `uvm_field_int(use_fast_intr_handler, UVM_DEFAULT)
+    `uvm_field_int(insert_rand_directed_instr_stream, UVM_DEFAULT)
+    `uvm_field_int(test_rand_directed_instr_stream_num, UVM_DEFAULT)
+    `uvm_field_int(num_zfinx_reserved_reg, UVM_DEFAULT)
+    `uvm_field_array_enum(riscv_reg_t, zfinx_reserved_gpr, UVM_DEFAULT)
   `uvm_object_utils_end
 
   function new(string name="");
@@ -120,7 +144,8 @@ class cv32e40p_instr_gen_config extends riscv_instr_gen_config;
                    $sformatf("Illegal combination of debug plusargs: enable_ebreak_in_debug_rom = %0d, set_dcsr_ebreakl = %0d, enable_debug_single_step = %0d",
                              enable_ebreak_in_debug_rom, set_dcsr_ebreak, enable_debug_single_step))
       end
-    end    
+    end
+
   endfunction : post_randomize
 
 endclass : cv32e40p_instr_gen_config

--- a/cv32e40p/env/corev-dv/cv32e40p_instr_test_pkg.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_instr_test_pkg.sv
@@ -24,6 +24,7 @@ package cv32e40p_instr_test_pkg;
   import riscv_signature_pkg::*;
   import corev_instr_test_pkg::*;
 
+  `include "cv32e40p_instr_gen_config.sv"
   // Instruction streams specific to CV32E40P
   // `include "instr_lib/cv32e40p_load_store_instr_lib.sv"
   `include "instr_lib/cv32e40p_base_instr_lib.sv"
@@ -37,7 +38,6 @@ package cv32e40p_instr_test_pkg;
   `include "cv32e40p_compressed_instr.sv"
   `include "cv32e40p_illegal_instr.sv"
   `include "cv32e40p_privil_reg.sv"
-  `include "cv32e40p_instr_gen_config.sv"
   `include "cv32e40p_debug_rom_gen.sv"
   `include "cv32e40p_asm_program_gen.sv"
   `include "cv32e40p_instr_base_test.sv"

--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_base_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_base_instr_lib.sv
@@ -21,6 +21,7 @@
  class cv32e40p_base_instr_stream extends riscv_rand_instr_stream;
 
   rand bit [31:0]           temp_imm; // variable used for immediate value randomization
+  cv32e40p_instr_gen_config cv32e40p_cfg;
 
   `uvm_object_utils(cv32e40p_base_instr_stream)
   int unsigned num_of_avail_regs;
@@ -30,6 +31,8 @@
   endfunction
 
   function void pre_randomize();
+    `DV_CHECK_FATAL($cast(cv32e40p_cfg, cfg), "Could not cast cfg into cv32e40p_cfg")
+    cv32e40p_cfg.print();
     super.pre_randomize();
   endfunction
 
@@ -199,6 +202,45 @@
       instr.extend_imm();
       instr.update_imm_str();
     end
+  endfunction
+
+  //Function: randomize_zfinx_gpr()
+  function void randomize_zfinx_gpr(riscv_fp_in_x_regs_instr instr, riscv_reg_t avail_reg_list[]);
+    instr.set_rand_mode();
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(instr,
+      if ( (instr.format != (CI_FORMAT || CB_FORMAT || CJ_FORMAT || CR_FORMAT || CA_FORMAT || CL_FORMAT || CS_FORMAT || CSS_FORMAT || CIW_FORMAT)) ) {
+        if (avail_reg_list.size() > 0) {
+          if (has_rs1) {
+            rs1 inside {avail_reg_list};
+          }
+          if (has_rs2) {
+            rs2 inside {avail_reg_list};
+          }
+          if (has_rs3) {
+            rs3 inside {avail_reg_list};
+          }
+          if (has_rd) {
+            rd  inside {avail_reg_list};
+          }
+        }
+        foreach (reserved_rd[i]) {
+          if (has_rd) {
+            rd != reserved_rd[i];
+          }
+          if (format == CB_FORMAT) {
+            rs1 != reserved_rd[i];
+          }
+        }
+        foreach (cfg.reserved_regs[i]) {
+          if (has_rd) {
+            rd != cfg.reserved_regs[i];
+          }
+          if (format == CB_FORMAT) {
+            rs1 != cfg.reserved_regs[i];
+          }
+        }
+      }
+    )
   endfunction
 
 endclass // cv32e40p_base_instr_stream

--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
@@ -907,6 +907,10 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
                       $sformatf("Too many hwloop instr. num_rand_instr = %0d",num_rand_instr))
       end
 
+      riscv_exclude_xpulp = {riscv_exclude_group, RV32X};
+      rv32_ins = $urandom_range(0,3);
+      pulp_ins = $urandom_range(0,3);
+
       i = 0;
       while (i < num_rand_instr) begin
           //Create and Randomize array for avail_regs each time to ensure randomization
@@ -914,8 +918,23 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
           randomize_avail_regs();
 
           instr = riscv_instr::type_id::create($sformatf("instr_%0d", i));
-          instr = riscv_instr::get_rand_instr(.exclude_instr(riscv_exclude_instr),
-                                              .exclude_group(riscv_exclude_group));
+
+          if((rv32_ins + pulp_ins) == 0) begin
+            instr = riscv_instr::get_rand_instr(.exclude_instr(riscv_exclude_instr),
+                                                .exclude_group(riscv_exclude_group));
+          end
+
+          randcase
+            pulp_ins: begin
+                        instr = riscv_instr::get_rand_instr(.exclude_instr(riscv_exclude_instr),
+                                                            .exclude_group(riscv_exclude_group));
+                      end
+
+            rv32_ins: begin
+                        instr = riscv_instr::get_rand_instr(.exclude_instr(riscv_exclude_instr),
+                                                            .exclude_group(riscv_exclude_xpulp));
+                      end
+          endcase
 
           //randomize GPRs for each instruction
           if(instr.group != RV32ZFINX)
@@ -942,6 +961,8 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
       riscv_instr                 instr;
       cv32e40p_instr              cv32_instr;
       riscv_fp_in_x_regs_instr    zfinx_instr;
+      riscv_instr_group_t         riscv_exclude_xpulp[];
+      int                         rv32_ins, pulp_ins;
 
       //use cfg for ebreak
       if(cfg.no_ebreak)
@@ -956,13 +977,32 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
       if(no_fence)
           riscv_exclude_instr = {riscv_exclude_instr, FENCE, FENCE_I};
 
+      riscv_exclude_xpulp = {riscv_exclude_group, RV32X};
+      rv32_ins = $urandom_range(0,2);
+      pulp_ins = $urandom_range(0,2);
+
       //Create and Randomize array for avail_regs each time to ensure randomization
       avail_regs = new[num_of_avail_regs];
       randomize_avail_regs();
 
       instr = riscv_instr::type_id::create($sformatf("instr_%0s", label_str));
-      instr = riscv_instr::get_rand_instr(.exclude_instr(riscv_exclude_instr),
-                                          .exclude_group(riscv_exclude_group));
+
+      if((rv32_ins + pulp_ins) == 0) begin
+        instr = riscv_instr::get_rand_instr(.exclude_instr(riscv_exclude_instr),
+                                            .exclude_group(riscv_exclude_group));
+      end
+
+      randcase
+        pulp_ins: begin
+                    instr = riscv_instr::get_rand_instr(.exclude_instr(riscv_exclude_instr),
+                                                        .exclude_group(riscv_exclude_group));
+                  end
+
+        rv32_ins: begin
+                    instr = riscv_instr::get_rand_instr(.exclude_instr(riscv_exclude_instr),
+                                                        .exclude_group(riscv_exclude_xpulp));
+                  end
+      endcase
 
       //randomize GPRs for each instruction
       if(instr.group != RV32ZFINX)

--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
@@ -890,10 +890,10 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
           riscv_exclude_instr = {riscv_exclude_instr, EBREAK, C_EBREAK};
 
       if(no_branch)
-          riscv_exclude_instr = {riscv_exclude_instr, BEQ, BNE, BLT, BGE, BLTU, BGEU, C_BEQZ, C_BNEZ};
+          riscv_exclude_instr = {riscv_exclude_instr, BEQ, BNE, BLT, BGE, BLTU, BGEU, C_BEQZ, C_BNEZ, CV_BEQIMM, CV_BNEIMM};
 
       if(no_compressed)
-          riscv_exclude_group = {riscv_exclude_group, RV32C};
+          riscv_exclude_group = {riscv_exclude_group, RV32C, RV32FC};
 
       if(no_fence)
           riscv_exclude_instr = {riscv_exclude_instr, FENCE, FENCE_I};
@@ -969,10 +969,10 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
           riscv_exclude_instr = {riscv_exclude_instr, EBREAK, C_EBREAK};
 
       if(no_branch)
-          riscv_exclude_instr = {riscv_exclude_instr, BEQ, BNE, BLT, BGE, BLTU, BGEU, C_BEQZ, C_BNEZ};
+          riscv_exclude_instr = {riscv_exclude_instr, BEQ, BNE, BLT, BGE, BLTU, BGEU, C_BEQZ, C_BNEZ, CV_BEQIMM, CV_BNEIMM};
 
       if(no_compressed)
-          riscv_exclude_group = {riscv_exclude_group, RV32C};
+          riscv_exclude_group = {riscv_exclude_group, RV32C, RV32FC};
 
       if(no_fence)
           riscv_exclude_instr = {riscv_exclude_instr, FENCE, FENCE_I};
@@ -1382,10 +1382,10 @@ class cv32e40p_xpulp_hwloop_isa_stress_stream extends cv32e40p_xpulp_hwloop_base
           riscv_exclude_instr = {riscv_exclude_instr, EBREAK, C_EBREAK};
 
       if(no_branch)
-          riscv_exclude_instr = {riscv_exclude_instr, BEQ, BNE, BLT, BGE, BLTU, BGEU, C_BEQZ, C_BNEZ};
+          riscv_exclude_instr = {riscv_exclude_instr, BEQ, BNE, BLT, BGE, BLTU, BGEU, C_BEQZ, C_BNEZ, CV_BEQIMM, CV_BNEIMM};
 
       if(no_compressed)
-          riscv_exclude_group = {riscv_exclude_group, RV32C};
+          riscv_exclude_group = {riscv_exclude_group, RV32C, RV32FC};
 
       if(no_fence)
           riscv_exclude_instr = {riscv_exclude_instr, FENCE, FENCE_I};

--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
@@ -102,6 +102,8 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
   cv32e40p_instr        hwloop_count_instr[2];
 
   static int            stream_count = 0;
+  string                start_label_s;
+  string                end_label_s;
 
   riscv_instr_category_t xpulp_exclude_category[];
 
@@ -255,6 +257,11 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
 
   function void post_randomize();
       uvm_default_printer.knobs.begin_elements = -1;
+
+      if((cv32e40p_exclude_regs.size() < 2) || (cv32e40p_exclude_regs.size() > 25)) begin
+        `uvm_fatal(this.get_type_name(), "cv32e40p_exclude_regs out of range")
+      end
+
       this.print();
       gen_xpulp_hwloop_control_instr();
   endfunction : post_randomize
@@ -307,8 +314,6 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
       riscv_instr           hwloop_instr_list[$];
       int unsigned          num_rem_hwloop1_instr; //indicates num of hwloop_1 body instructions after  hwloop_0 body for nested hwloops
       string                label_s;
-      string                start_label_s;
-      string                end_label_s;
 
       num_instr_cv_start_to_loop_start_label[0] = num_fill_instr_loop_ctrl_to_loop_start[0] + 2;//TODO: can be randomized?
       num_instr_cv_start_to_loop_start_label[1] = num_fill_instr_loop_ctrl_to_loop_start[1] + 2;//TODO: can be randomized?
@@ -874,8 +879,11 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
                                           bit no_compressed=1,
                                           bit no_fence=1);
 
-      riscv_instr instr;
-      int unsigned i;
+      riscv_instr                 instr;
+      riscv_fp_in_x_regs_instr    zfinx_instr;
+      int unsigned                i;
+      riscv_instr_group_t         riscv_exclude_xpulp[];
+      int                         rv32_ins, pulp_ins;
 
       //use cfg for ebreak
       if(cfg.no_ebreak)
@@ -910,7 +918,12 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
                                               .exclude_group(riscv_exclude_group));
 
           //randomize GPRs for each instruction
-          randomize_gpr(instr);
+          if(instr.group != RV32ZFINX)
+            randomize_gpr(instr);
+          else begin
+            `DV_CHECK_FATAL($cast(zfinx_instr, instr), "Cast to zfinx instruction type failed!");
+            randomize_zfinx_gpr(zfinx_instr, cv32e40p_zfinx_regs);
+          end
 
           //randomize immediates for each instruction
           randomize_riscv_instr_imm(instr);
@@ -926,8 +939,9 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
                                                      bit no_branch=1,
                                                      bit no_compressed=1,
                                                      bit no_fence=1);
-      riscv_instr instr;
-      cv32e40p_instr cv32_instr;
+      riscv_instr                 instr;
+      cv32e40p_instr              cv32_instr;
+      riscv_fp_in_x_regs_instr    zfinx_instr;
 
       //use cfg for ebreak
       if(cfg.no_ebreak)
@@ -951,7 +965,13 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
                                           .exclude_group(riscv_exclude_group));
 
       //randomize GPRs for each instruction
-      randomize_gpr(instr);
+      if(instr.group != RV32ZFINX)
+        randomize_gpr(instr);
+      else begin
+        `DV_CHECK_FATAL($cast(zfinx_instr, instr), "Cast to zfinx instruction type failed!");
+        randomize_zfinx_gpr(zfinx_instr, cv32e40p_zfinx_regs);
+      end
+
       //randomize immediates for each instruction
       randomize_riscv_instr_imm(instr);
       instr.has_label=1;
@@ -1312,9 +1332,10 @@ class cv32e40p_xpulp_hwloop_isa_stress_stream extends cv32e40p_xpulp_hwloop_base
                                           bit no_compressed=1,
                                           bit no_fence=1);
 
-      riscv_instr         instr;
-      cv32e40p_instr      cv32_instr;
-      int unsigned i;
+      riscv_instr                 instr;
+      cv32e40p_instr              cv32_instr;
+      riscv_fp_in_x_regs_instr    zfinx_instr;
+      int unsigned                i;
 
       //use cfg for ebreak
       if(cfg.no_ebreak)
@@ -1361,7 +1382,12 @@ class cv32e40p_xpulp_hwloop_isa_stress_stream extends cv32e40p_xpulp_hwloop_base
 
           //randomize GPRs and immediates for each instruction
           if(instr.group != RV32X) begin
-            randomize_gpr(instr);
+            if(instr.group != RV32ZFINX)
+              randomize_gpr(instr);
+            else begin
+              `DV_CHECK_FATAL($cast(zfinx_instr, instr), "Cast to zfinx instruction type failed!");
+              randomize_zfinx_gpr(zfinx_instr, cv32e40p_zfinx_regs);
+            end
             randomize_riscv_instr_imm(instr);
             instr_list.push_back(instr);
           end

--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_instr_lib.sv
@@ -106,6 +106,9 @@ class cv32e40p_xpulp_rand_stream extends cv32e40p_base_instr_stream;
   riscv_instr_group_t       riscv_exclude_group[];
   riscv_instr               riscv_instr_list[];
 
+  int unsigned              num_zfinx_gpr;
+  riscv_reg_t               cv32e40p_zfinx_regs[];
+
   `uvm_object_utils_begin(cv32e40p_xpulp_rand_stream)
       `uvm_field_int(num_of_xpulp_instr, UVM_DEFAULT)
       `uvm_field_int(num_of_riscv_instr, UVM_DEFAULT)
@@ -128,16 +131,26 @@ class cv32e40p_xpulp_rand_stream extends cv32e40p_base_instr_stream;
   }
 
   constraint avail_regs_pulp_instr_c {
-    num_of_avail_regs inside {[8:25]};
+    if ((cfg.enable_fp_in_x_regs == 1) && (RV32ZFINX inside {riscv_instr_pkg::supported_isa})) {
+      num_of_avail_regs  >= 8;
+      num_of_avail_regs  <= 25 - num_zfinx_gpr;
+    } else {
+      num_of_avail_regs inside {[8:25]};
+    }
   }
 
   constraint cv32e40p_avail_regs_c {
     solve num_of_avail_regs before cv32e40p_exclude_regs;
     cv32e40p_avail_regs.size() == num_of_avail_regs;
-    cv32e40p_exclude_regs.size() == (32-num_of_reserved_regs-num_of_avail_regs);
+    if ((cfg.enable_fp_in_x_regs == 1) && (RV32ZFINX inside {riscv_instr_pkg::supported_isa})) {
+      cv32e40p_exclude_regs.size() == (32-num_of_reserved_regs-num_of_avail_regs-num_zfinx_gpr);
+    } else {
+      cv32e40p_exclude_regs.size() == (32-num_of_reserved_regs-num_of_avail_regs);
+    }
     unique {cv32e40p_exclude_regs};
     foreach(cv32e40p_exclude_regs[i]) {
       !(cv32e40p_exclude_regs[i] inside {cv32e40p_reserved_regs});
+      !(cv32e40p_exclude_regs[i] inside {cv32e40p_zfinx_regs});
     }
   }
 
@@ -153,14 +166,12 @@ class cv32e40p_xpulp_rand_stream extends cv32e40p_base_instr_stream;
   function void pre_randomize();
     super.pre_randomize();
     //Exclude list for XPULP instruction generation part
-    xpulp_exclude_instr = {  CV_BEQIMM, CV_BNEIMM,
-                             CV_START, CV_STARTI, CV_END, CV_ENDI, CV_COUNT, CV_COUNTI, CV_SETUP, CV_SETUPI,
+    xpulp_exclude_instr = {  CV_START, CV_STARTI, CV_END, CV_ENDI, CV_COUNT, CV_COUNTI, CV_SETUP, CV_SETUPI,
                              CV_ELW,
                              C_ADDI16SP };
 
     //Exclude list for all random instruction generation part
-    riscv_exclude_instr = {  CV_BEQIMM, CV_BNEIMM,
-                             CV_START, CV_STARTI, CV_END, CV_ENDI, CV_COUNT, CV_COUNTI, CV_SETUP, CV_SETUPI,
+    riscv_exclude_instr = {  CV_START, CV_STARTI, CV_END, CV_ENDI, CV_COUNT, CV_COUNTI, CV_SETUP, CV_SETUPI,
                              CV_ELW,
                              C_ADDI16SP,
                              WFI,
@@ -168,15 +179,23 @@ class cv32e40p_xpulp_rand_stream extends cv32e40p_base_instr_stream;
                              ECALL,
                              JALR, JAL, C_JR, C_JALR, C_J, C_JAL};
 
+    num_zfinx_gpr = cv32e40p_cfg.num_zfinx_reserved_reg;
+    cv32e40p_zfinx_regs = new[num_zfinx_gpr];
+    cv32e40p_zfinx_regs = cv32e40p_cfg.zfinx_reserved_gpr;
+
   endfunction : pre_randomize
 
   function void post_randomize();
     cv32e40p_exclude_regs = {cv32e40p_exclude_regs,cv32e40p_reserved_regs};
+
+    if((cv32e40p_exclude_regs.size() < 2) || (cv32e40p_exclude_regs.size() > 25))
+      `uvm_fatal(this.get_type_name(), "cv32e40p_exclude_regs out of range")
+
     this.print();
     insert_rand_xpulp_instr(.no_branch(cfg.no_branch_jump),
                             .no_compressed(cfg.disable_compressed_instr),
                             .no_fence(cfg.no_fence),
-                            .no_floating_point_instr(!cfg.enable_floating_point));
+                            .no_floating_point_instr(~(cfg.enable_floating_point | cfg.enable_fp_in_x_regs)));
 
     //super.post_randomize();
   endfunction : post_randomize
@@ -186,17 +205,18 @@ class cv32e40p_xpulp_rand_stream extends cv32e40p_base_instr_stream;
                                            bit no_fence=1,
                                            bit no_floating_point_instr=0);
 
-    riscv_instr         instr;
-    cv32e40p_instr      cv32_instr;
-    string              str;
-    int                 i;
+    riscv_instr                 instr;
+    cv32e40p_instr              cv32_instr;
+    riscv_fp_in_x_regs_instr    zfinx_instr;
+    string                      str;
+    int                         i;
 
     //use cfg for ebreak
     if(cfg.no_ebreak)
         riscv_exclude_instr = {riscv_exclude_instr, EBREAK, C_EBREAK};
 
     if(no_branch)
-        riscv_exclude_instr = {riscv_exclude_instr, BEQ, BNE, BLT, BGE, BLTU, BGEU, C_BEQZ, C_BNEZ};
+        riscv_exclude_instr = {riscv_exclude_instr, BEQ, BNE, BLT, BGE, BLTU, BGEU, C_BEQZ, C_BNEZ, CV_BEQIMM, CV_BNEIMM};
 
     if(no_compressed)
         riscv_exclude_group = {riscv_exclude_group, RV32C};
@@ -254,7 +274,12 @@ class cv32e40p_xpulp_rand_stream extends cv32e40p_base_instr_stream;
                                                         .exclude_group(riscv_exclude_group));
 
       //randomize GPRs for each instruction
-      randomize_gpr(riscv_instr_list[i]);
+      if(riscv_instr_list[i].group != RV32ZFINX)
+        randomize_gpr(riscv_instr_list[i]);
+      else begin
+        `DV_CHECK_FATAL($cast(zfinx_instr, riscv_instr_list[i]), "Cast to zfinx instruction type failed!");
+        randomize_zfinx_gpr(zfinx_instr, cv32e40p_zfinx_regs);
+      end
 
       //randomize immediates for each instruction
       randomize_riscv_instr_imm(riscv_instr_list[i]);

--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_instr_lib.sv
@@ -219,7 +219,7 @@ class cv32e40p_xpulp_rand_stream extends cv32e40p_base_instr_stream;
         riscv_exclude_instr = {riscv_exclude_instr, BEQ, BNE, BLT, BGE, BLTU, BGEU, C_BEQZ, C_BNEZ, CV_BEQIMM, CV_BNEIMM};
 
     if(no_compressed)
-        riscv_exclude_group = {riscv_exclude_group, RV32C};
+        riscv_exclude_group = {riscv_exclude_group, RV32C, RV32FC};
 
     if(no_fence)
         riscv_exclude_instr = {riscv_exclude_instr, FENCE, FENCE_I};

--- a/cv32e40p/env/corev-dv/target/cv32e40p/cv32e40p_supported_isa.svh
+++ b/cv32e40p/env/corev-dv/target/cv32e40p/cv32e40p_supported_isa.svh
@@ -9,7 +9,7 @@
     `define RV_DV_ISA { RV32I, RV32M, RV32C, RV32X }
   `else //FPU = 1
     `ifndef ZFINX
-      `define RV_DV_ISA { RV32I, RV32M, RV32C, RV32X, RV32F }
+      `define RV_DV_ISA { RV32I, RV32M, RV32C, RV32X, RV32F, RV32FC }
     `else
       `define FP_IN_X_REGS
       `define RV_DV_ISA { RV32I, RV32M, RV32C, RV32X, RV32ZFINX }
@@ -18,7 +18,7 @@
 `else //PULP = 0, FPU = 1
   `ifdef FPU
     `ifndef ZFINX
-      `define RV_DV_ISA { RV32I, RV32M, RV32C, RV32F }
+      `define RV_DV_ISA { RV32I, RV32M, RV32C, RV32F, RV32FC }
     `else
       `define FP_IN_X_REGS
       `define RV_DV_ISA { RV32I, RV32M, RV32C, RV32ZFINX }
@@ -28,7 +28,7 @@
 
 //Following defines are provided to allow overwrite from test yaml files
 `ifdef RV_DV_ISA_RV32IMFC
-`define RV_DV_ISA { RV32I, RV32M, RV32C, RV32F }
+`define RV_DV_ISA { RV32I, RV32M, RV32C, RV32F, RV32FC }
 `endif
 
 `ifdef RV_DV_ISA_RV32IMC_ZFINX
@@ -41,7 +41,7 @@
 `endif
 
 `ifdef RV_DV_ISA_RV32IMFC_X
-`define RV_DV_ISA { RV32I, RV32M, RV32C, RV32F, RV32X }
+`define RV_DV_ISA { RV32I, RV32M, RV32C, RV32F, RV32FC, RV32X }
 `endif
 
 `ifdef RV_DV_ISA_RV32IMC_ZFINX_X

--- a/cv32e40p/sim/ExternalRepos.mk
+++ b/cv32e40p/sim/ExternalRepos.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40p
 CV_CORE_BRANCH ?= dev
-CV_CORE_HASH   ?= 73ff0c15eef61cf7f1882dbf6f62ce5ada1216f3
+CV_CORE_HASH   ?= 0b47ca45a2a0c3fdfa71632dd245b9c4e57a82db
 CV_CORE_TAG    ?= none
 
 # The CV_CORE_HASH above points to version of the RTL that is newer.

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_imperas_riscv_coverage_config.svh
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_imperas_riscv_coverage_config.svh
@@ -18,6 +18,7 @@
   `ifdef FPU
     `ifndef ZFINX
       `define COVER_RV32F
+      `define COVER_RV32ZCF
     `else
       `define COVER_RV32ZFINX
     `endif

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_imperas_riscv_coverage_config.svh
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_imperas_riscv_coverage_config.svh
@@ -15,6 +15,7 @@
   `define COVER_RV32M
   `define COVER_RV32C
   `define COVER_RVVI_METRICS
+
   `ifdef FPU
     `ifndef ZFINX
       `define COVER_RV32F
@@ -22,5 +23,20 @@
     `else
       `define COVER_RV32ZFINX
     `endif
+  `else
+    `define COVER_RV32F_ILLEGAL
+    `define COVER_RV32ZCF_ILLEGAL
+  `endif
+
+  `ifdef PULP
+    `define COVER_XPULPV2
+    `ifdef CLUSTER
+      `define COVER_XPULPV2C
+    `else
+      `define COVER_XPULPV2C_ILLEGAL
+    `endif
+  `else
+    `define COVER_XPULPV2_ILLEGAL
+    `define COVER_XPULPV2C_ILLEGAL
   `endif
 `endif


### PR DESCRIPTION
This PR contains updates to corev-dv tb files:

1. Update the common files to support zfinx instructions with relevant register randomization, constraints, and initialization as done for rv32f instructions
2. Add RV32FC instructions to the supported ISA
3. Extend riscv_compressed_instr class to support rv32fc instructions and use the extended class to generate instructions of this group
4. Update pulp instruction streams for both the above updates for zfinx and rv32fc instructions