### PR TITLE
Addition of "feature-centered" regressions & fixes to regress script

### DIFF
--- a/bin/cv_regress
+++ b/bin/cv_regress
@@ -160,8 +160,12 @@ def read_file(args, file):
             check_valid_test(args.project, test.testname)
 
         # Determine if a test is indexed for setting test iterations
-        if args.num:
-            test.num = int(args.num)
+        # if num is not specified in the yaml, it can be overriden by args.num or set to 1 to avoid issues
+        # else, if it is not set to 1 (unique), it can be overriden by args.num if argument is defined
+        if test.num == None:
+            test.num = int(args.num or 1)
+        elif test.num != 1:
+            test.num = int(args.num or test.num)
 
         regression.add_test(test)
 

--- a/bin/lib/cv_regression.py
+++ b/bin/lib/cv_regression.py
@@ -76,7 +76,8 @@ class Test:
         self.simulation_passed = DEFAULT_SIMULATION_PASSED
         self.simulation_failed = DEFAULT_SIMULATION_FAILED
         self.iss = DEFAULT_ISS
-        self.num = 1
+        # value is handled in main cv_regress script
+        self.num = None
         self.builds = []
 
         for k, v in kwargs.items():

--- a/cv32e40p/regress/cv32e40pv2_fpu_instr.yaml
+++ b/cv32e40p/regress/cv32e40pv2_fpu_instr.yaml
@@ -1,0 +1,90 @@
+# Copyright 2023 Dolphin Design
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+# Header
+name: cv32e40pv2_fpu_instr
+description: regression for CV32E40Pv2, focused on FP instructions excluding hwloop, debug, interrupts, etc.
+
+# List of builds
+builds:
+  clean_fw:
+    cmd: make clean-bsp clean_test_programs
+    dir: cv32e40p/sim/uvmt
+  clean_corev-dv:
+    cmd: make clean_riscv-dv clone_riscv-dv
+    dir: cv32e40p/sim/uvmt
+  uvmt_cv32e40p:
+    cmd: make comp comp_corev-dv
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp_fpu
+  uvmt_cv32e40p_zfinx:
+    cmd: make comp comp_corev-dv
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp_fpu_zfinx
+
+# List of tests
+tests:
+  corev_rand_fp_instr_sanity_test:
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_fp_instr_sanity_test CFG_PLUSARGS="+UVM_TIMEOUT=1000000"
+    test_cfg: floating_pt_instr_en
+
+  corev_rand_fp_instr_test:
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_fp_instr_test CFG_PLUSARGS="+UVM_TIMEOUT=1000000"
+    test_cfg: floating_pt_instr_en
+
+  corev_rand_fp_instr_data_fwd_test:
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_fp_instr_data_fwd_test CFG_PLUSARGS="+UVM_TIMEOUT=1000000"
+    test_cfg: floating_pt_instr_en
+
+  corev_rand_fp_instr_mlt_cyc_test:
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_fp_instr_mlt_cyc_test CFG_PLUSARGS="+UVM_TIMEOUT=1000000"
+    test_cfg: floating_pt_instr_en
+
+  corev_rand_fp_instr_w_special_ops_test:
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_fp_instr_w_special_ops_test CFG_PLUSARGS="+UVM_TIMEOUT=1000000"
+    test_cfg: floating_pt_instr_en
+
+  corev_rand_fp_instr_sanity_test_zfinx:
+    testname: corev_rand_fp_instr_sanity_test
+    build: uvmt_cv32e40p_zfinx
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_fp_instr_sanity_test CFG_PLUSARGS="+UVM_TIMEOUT=1000000"
+    test_cfg: floating_pt_zfinx_instr_en
+
+  corev_rand_fp_instr_test_zfinx:
+    testname: corev_rand_fp_instr_test
+    build: uvmt_cv32e40p_zfinx
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_fp_instr_test CFG_PLUSARGS="+UVM_TIMEOUT=1000000"
+    test_cfg: floating_pt_zfinx_instr_en
+
+  corev_rand_fp_instr_data_fwd_test_zfinx:
+    testname: corev_rand_fp_instr_data_fwd_test
+    build: uvmt_cv32e40p_zfinx
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_fp_instr_data_fwd_test CFG_PLUSARGS="+UVM_TIMEOUT=1000000"
+    test_cfg: floating_pt_zfinx_instr_en
+
+  corev_rand_fp_instr_mlt_cyc_test_zfinx:
+    testname: corev_rand_fp_instr_mlt_cyc_test
+    build: uvmt_cv32e40p_zfinx
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_fp_instr_mlt_cyc_test CFG_PLUSARGS="+UVM_TIMEOUT=1000000"
+    test_cfg: floating_pt_zfinx_instr_en
+
+  corev_rand_fp_instr_w_special_ops_test_zfinx:
+    testname: corev_rand_fp_instr_w_special_ops_test
+    build: uvmt_cv32e40p_zfinx
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_fp_instr_w_special_ops_test CFG_PLUSARGS="+UVM_TIMEOUT=1000000"
+    test_cfg: floating_pt_zfinx_instr_en

--- a/cv32e40p/regress/cv32e40pv2_hwloop_instr.yaml
+++ b/cv32e40p/regress/cv32e40pv2_hwloop_instr.yaml
@@ -1,0 +1,33 @@
+# Copyright 2023 Dolphin Design
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+# Header
+name: cv32e40pv2_fpu_instr
+description: regression for CV32E40Pv2, focused on hwloop (including interrupt and debug as well)
+
+# List of builds
+builds:
+  clean_fw:
+    cmd: make clean-bsp clean_test_programs
+    dir: cv32e40p/sim/uvmt
+  clean_corev-dv:
+    cmd: make clean_riscv-dv clone_riscv-dv
+    dir: cv32e40p/sim/uvmt
+  uvmt_cv32e40p:
+    cmd: make comp comp_corev-dv
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp
+
+# List of tests
+tests:
+  corev_rand_pulp_hwloop_test:
+    build: uvmt_cv32e40p
+    description: corev_rand_pulp_hwloop_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_hwloop_test
+
+  corev_rand_pulp_hwloop_debug:
+    build: uvmt_cv32e40p
+    description: corev_rand_pulp_hwloop_debug
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_hwloop_debug

--- a/cv32e40p/regress/cv32e40pv2_interrupt_debug.yaml
+++ b/cv32e40p/regress/cv32e40pv2_interrupt_debug.yaml
@@ -1,0 +1,89 @@
+# Copyright 2023 Dolphin Design
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+# Header
+name: cv32e40pv2_fpu_instr
+description: regression for CV32E40Pv2, focused on debug and interrupt without hwloop
+
+# List of builds
+builds:
+  clean_fw:
+    cmd: make clean-bsp clean_test_programs
+    dir: cv32e40p/sim/uvmt
+  clean_corev-dv:
+    cmd: make clean_riscv-dv clone_riscv-dv
+    dir: cv32e40p/sim/uvmt
+  uvmt_cv32e40p:
+    cmd: make comp comp_corev-dv
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp
+
+# List of tests
+tests:
+  corev_rand_debug_ebreak_xpulp:
+    build: uvmt_cv32e40p
+    description: corev_rand_debug_ebreak_xpulp
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak_xpulp
+
+  corev_rand_debug_single_step_xpulp:
+    build: uvmt_cv32e40p
+    description: corev_rand_debug_single_step_xpulp
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_single_step_xpulp
+    test_cfg: debug_single_step_en
+
+  corev_rand_debug:
+    build: uvmt_cv32e40p
+    description: corev_rand_debug
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug
+
+  corev_rand_debug_ebreak:
+    build: uvmt_cv32e40p
+    description: corev_rand_debug_ebreak
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak
+
+  corev_rand_debug_single_step:
+    build: uvmt_cv32e40p
+    description: corev_rand_debug_single_step
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_single_step
+    test_cfg: debug_single_step_en
+
+  corev_rand_interrupt:
+    build: uvmt_cv32e40p
+    description: corev_rand_interrupt
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt
+
+  corev_rand_interrupt_debug:
+    build: uvmt_cv32e40p
+    description: corev_rand_interrupt_debug
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_debug
+
+  corev_rand_interrupt_exception:
+    build: uvmt_cv32e40p
+    description: corev_rand_interrupt_exception
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_exception
+
+  corev_rand_interrupt_nested:
+    build: uvmt_cv32e40p
+    description: corev_rand_interrupt_nested
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_nested
+
+  corev_rand_interrupt_wfi:
+    build: uvmt_cv32e40p
+    description: corev_rand_interrupt_wfi
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi
+
+  corev_rand_interrupt_wfi_mem_stress:
+    build: uvmt_cv32e40p
+    description: corev_rand_interrupt_wfi_mem_stress
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress

--- a/cv32e40p/regress/cv32e40pv2_pulp_instr.yaml
+++ b/cv32e40p/regress/cv32e40pv2_pulp_instr.yaml
@@ -1,0 +1,180 @@
+# Copyright 2023 Dolphin Design
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+# Header
+name: cv32e40pv2_pulp_instr
+description: regression for CV32E40Pv2, focused on simple PULP instructions excluding hwloop, debug, interrupts, fpu instr, etc.
+
+# List of builds
+builds:
+  clean_fw:
+    cmd: make clean-bsp clean_test_programs
+    dir: cv32e40p/sim/uvmt
+  clean_corev-dv:
+    cmd: make clean_riscv-dv clone_riscv-dv
+    dir: cv32e40p/sim/uvmt
+  uvmt_cv32e40p:
+    cmd: make comp comp_corev-dv
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp_fpu
+
+# ====================================================================================
+# List of tests
+tests:
+  # ====================================================================================
+  # V2 PULP tests
+  # ====================================================================================
+  corev_rand_pulp_instr_test:
+    build: uvmt_cv32e40p
+    description: corev_rand_pulp_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_instr_test
+
+  corev_rand_pulp_simd_instr_test:
+    build: uvmt_cv32e40p
+    description: corev_rand_pulp_simd_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_simd_instr_test
+
+  corev_rand_pulp_mac_instr_test:
+    build: uvmt_cv32e40p
+    description: corev_rand_pulp_mac_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_mac_instr_test
+
+# ====================================================================================
+# V1 legacy pulp tests
+# ====================================================================================
+
+  pulp_bit_manipulation:
+    build: uvmt_cv32e40p
+    description: pulp_bit_manipulation legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=pulp_bit_manipulation
+    num: 1
+
+  pulp_general_alu:
+    build: uvmt_cv32e40p
+    description: pulp_general_alu legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=pulp_general_alu
+    num: 1
+
+  pulp_immediate_branching:
+    build: uvmt_cv32e40p
+    description: pulp_immediate_branching legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=pulp_immediate_branching
+    num: 1
+
+  pulp_multiply_accumulate:
+    build: uvmt_cv32e40p
+    description: pulp_multiply_accumulate legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=pulp_multiply_accumulate
+    num: 1
+
+  pulp_post_increment_load_store:
+    build: uvmt_cv32e40p
+    description: pulp_post_increment_load_store legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=pulp_post_increment_load_store
+    num: 1
+
+  pulp_vectorial_add_sub:
+    build: uvmt_cv32e40p
+    description: pulp_vectorial_add_sub legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=pulp_vectorial_add_sub
+    num: 1
+
+  pulp_vectorial_avg:
+    build: uvmt_cv32e40p
+    description: pulp_vectorial_avg legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=pulp_vectorial_avg
+    num: 1
+
+  pulp_vectorial_bit_manip:
+    build: uvmt_cv32e40p
+    description: pulp_vectorial_bit_manip legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=pulp_vectorial_bit_manip
+    num: 1
+
+  pulp_vectorial_bitwise:
+    build: uvmt_cv32e40p
+    description: pulp_vectorial_bitwise legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=pulp_vectorial_bitwise
+    num: 1
+
+  pulp_vectorial_comparison_1:
+    build: uvmt_cv32e40p
+    description: pulp_vectorial_comparison_1 legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=pulp_vectorial_comparison_1
+    num: 1
+
+  pulp_vectorial_comparison_2:
+    build: uvmt_cv32e40p
+    description: pulp_vectorial_comparison_2 legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=pulp_vectorial_comparison_2
+    num: 1
+
+  pulp_vectorial_comparison_3:
+    build: uvmt_cv32e40p
+    description: pulp_vectorial_comparison_3 legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=pulp_vectorial_comparison_3
+    num: 1
+
+  pulp_vectorial_complex:
+    build: uvmt_cv32e40p
+    description: pulp_vectorial_complex legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=pulp_vectorial_complex
+    num: 1
+
+  pulp_vectorial_dot_product_1:
+    build: uvmt_cv32e40p
+    description: pulp_vectorial_dot_product_1 legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=pulp_vectorial_dot_product_1
+    num: 1
+
+  pulp_vectorial_dot_product_2:
+    build: uvmt_cv32e40p
+    description: pulp_vectorial_dot_product_2 legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=pulp_vectorial_dot_product_2
+    num: 1
+
+  pulp_vectorial_max:
+    build: uvmt_cv32e40p
+    description: pulp_vectorial_max legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=pulp_vectorial_max
+    num: 1
+
+  pulp_vectorial_min:
+    build: uvmt_cv32e40p
+    description: pulp_vectorial_min legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=pulp_vectorial_min
+    num: 1
+
+  pulp_vectorial_shift:
+    build: uvmt_cv32e40p
+    description: pulp_vectorial_shift legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=pulp_vectorial_shift
+    num: 1
+
+  pulp_vectorial_shuffle_pack:
+    build: uvmt_cv32e40p
+    description: pulp_vectorial_shuffle_pack legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=pulp_vectorial_shuffle_pack
+    num: 1

--- a/mk/uvmt/vsim.mk
+++ b/mk/uvmt/vsim.mk
@@ -208,7 +208,12 @@ endif
 ifeq ($(call IS_YES,$(COV)),YES)
 VOPT_FLAGS  += $(VOPT_COV)
 VSIM_FLAGS  += $(VSIM_COV)
-VSIM_FLAGS  += -do 'set TEST ${VSIM_TEST}; set TEST_CONFIG $(CFG); set TEST_SEED $(RNDSEED); source $(VSIM_SCRIPT_DIR)/cov.tcl'
+# VSIM_FLAGS  += -do 'set TEST ${VSIM_TEST}; set TEST_CONFIG $(CFG); set TEST_SEED $(RNDSEED); source $(VSIM_SCRIPT_DIR)/cov.tcl'
+ifneq ($(TEST_CFG_FILE),)
+VSIM_FLAGS  += -do 'setenv TEST_COV ${TEST}; setenv TEST_CONFIG_COV $(CFG); setenv TEST_CFG_FILE_COV \"__$(TEST_CFG_FILE)\"; setenv TEST_SEED_COV $(RNDSEED); source $(VSIM_SCRIPT_DIR)/cov.tcl'
+else
+VSIM_FLAGS  += -do 'setenv TEST_COV ${TEST}; setenv TEST_CONFIG_COV $(CFG); setenv TEST_CFG_FILE_COV \"\"; setenv TEST_SEED_COV $(RNDSEED); source $(VSIM_SCRIPT_DIR)/cov.tcl'
+endif
 endif
 
 ################################################################################


### PR DESCRIPTION
First addition of 4 feature-oriented regression scripts.

1. FPU (+Zfinx)
2. PULP w/o HWLoops
3. Interrupt & Debug
4.  HWLoops (with available hwloop debug test) 

@dd-baoshan I also made a small modification to the num behavior of the regress script, because I found out that when you have a test that makes no sense to be executed multiple times (e.g. directed without any random features), it is executed anyway as many times you specify with the num command switch.

I also included a small fix for the warning message you told me about (TEST variable undefined), but it will need more work as I understood why Jenkins VRM plugin is failing and it is linked to that. 

I will merge this without delay to start the regression this week-end, but we can discuss this next monday, of course. 

