### PR TITLE
TEST_CFG_FILE update to support multiple test_cfg yamls

### DIFF
--- a/mk/README.md
+++ b/mk/README.md
@@ -415,13 +415,23 @@ The following will increase the verbosity level to DEBUG.
 
 For a given test, test.yaml file would typically have all the relevant plusargs for that test, but in certain cases there are new features or updates added to TB, or there is a need to run all the tests with a new TB config, say for example a particular bus delay config. This would previously require to either update all existing tests with new plusargs, or add new tests just for this requirement.
 
-Using this **TEST_CFG_FILE** allows us to retain all existing test setup while providing a simple mechanism to run those tests with additional configs, on top of the ones in test.yaml, passed through a separate yaml file provided using variable TEST_CFG_FILE with the make command.
+Using this **TEST_CFG_FILE** allows us to retain all existing test setup while providing a simple mechanism to run those tests with additional configs, on top of the ones in test.yaml, passed through separate yaml file(s) provided using variable TEST_CFG_FILE with the make command.
 
-This is different from above **USER_RUN_FLAGS** method, as this would also create a unique directory path, log names, coverage db etc. suffixed with TEST_CFG_FILE name, and hence this mechanism goes beyond the **USER_RUN_FLAGS** method in a sense that it provides a way to run tests through regression scripts as unique tests differentitated from same default TEST by TEST_CFG_FILE. And hence such tests can be also be rerun, for example in case of failing tests from regression report, without the knowledge of CMD line arguments such as the ones passed through USER_RUN_FLAGS mechanism.
+This is different from above **USER_RUN_FLAGS** method, as this would also create a unique directory path, log names, coverage db etc. suffixed with unique name based on TEST_CFG_FILE arguments, and hence this mechanism goes beyond the **USER_RUN_FLAGS** method in a sense that it provides a way to run tests through regression scripts as unique tests differentitated from same default TEST by TEST_CFG_FILE. And hence such tests can be also be rerun, for example in case of failing tests from regression report, without the knowledge of CMD line arguments such as the ones passed through USER_RUN_FLAGS mechanism.
+
+TEST_CFG_FILE can take multiple yaml files as input. Such multiple yaml file can be provided by adding separators "," or "+" or a "whitespace"
 
 Example:
 
 **make gen_corev-dv test TEST=corev_rand_arithmetic_base_test USE_ISS=no CFG=pulp_fpu WAVES=1 SEED=random TEST_CFG_FILE=floating_pt_instr_en**
+
+**make gen_corev-dv test TEST=corev_rand_arithmetic_base_test USE_ISS=no CFG=pulp_fpu WAVES=1 SEED=random TEST_CFG_FILE=floating_pt_instr_en,debug_ebreak**
+
+**make gen_corev-dv test TEST=corev_rand_arithmetic_base_test USE_ISS=no CFG=pulp_fpu WAVES=1 SEED=random TEST_CFG_FILE=floating_pt_instr_en,debug_ebreak,insert_illegal_instr**
+
+**make gen_corev-dv test TEST=corev_rand_arithmetic_base_test USE_ISS=no CFG=pulp_fpu WAVES=1 SEED=random TEST_CFG_FILE=floating_pt_instr_en+debug_ebreak**
+
+**make gen_corev-dv test TEST=corev_rand_arithmetic_base_test USE_ISS=no CFG=pulp_fpu WAVES=1 SEED=random TEST_CFG_FILE="floating_pt_instr_en debug_ebreak"**
 
 ### Post-process Waveform Debug
 

--- a/mk/uvmt/uvmt.mk
+++ b/mk/uvmt/uvmt.mk
@@ -95,10 +95,10 @@ export RUN_INDEX       ?= 0
 
 # Common test runtime plusargs from external file, used as test-configuration
 # Test Name with test-configuration
-TEST_RUN_NAME =  $(if $(TEST_CFG_FILE),$(TEST)_$(TEST_CFG_FILE),$(TEST))
-# Build unique _suffix based on TEST_CFG_FILE, for unique test log files and ucdb file names
-ifneq ($(TEST_CFG_FILE),)
-export TEST_CFG_FILE_SUFFIX=_$(TEST_CFG_FILE)
+TEST_RUN_NAME =  $(if $(TEST_CFG_FILE_NAME),$(TEST)_$(TEST_CFG_FILE_NAME),$(TEST))
+# Build unique _suffix based on TEST_CFG_FILE_NAME, for unique test log files and ucdb file names
+ifneq ($(TEST_CFG_FILE_NAME),)
+export TEST_CFG_FILE_SUFFIX=_$(TEST_CFG_FILE_NAME)
 endif
 
 # Common output directories
@@ -106,7 +106,7 @@ SIM_RESULTS             ?= $(if $(CV_RESULTS),$(abspath $(CV_RESULTS))/$(SIMULAT
 SIM_CFG_RESULTS          = $(SIM_RESULTS)/$(CFG)
 SIM_COREVDV_RESULTS      = $(SIM_CFG_RESULTS)/corev-dv
 SIM_LDGEN_RESULTS        = $(SIM_CFG_RESULTS)/$(LDGEN)
-SIM_TEST_RESULTS         = $(if $(TEST_CFG_FILE),$(SIM_CFG_RESULTS)/$(TEST)/$(TEST_CFG_FILE),$(SIM_CFG_RESULTS)/$(TEST))
+SIM_TEST_RESULTS         = $(if $(TEST_CFG_FILE_NAME),$(SIM_CFG_RESULTS)/$(TEST)/$(TEST_CFG_FILE_NAME),$(SIM_CFG_RESULTS)/$(TEST))
 SIM_RUN_RESULTS          = $(SIM_TEST_RESULTS)/$(RUN_INDEX)
 SIM_TEST_PROGRAM_RESULTS = $(SIM_RUN_RESULTS)/test_program
 SIM_BSP_RESULTS          = $(SIM_TEST_PROGRAM_RESULTS)/bsp

--- a/mk/uvmt/vsim.mk
+++ b/mk/uvmt/vsim.mk
@@ -203,7 +203,7 @@ VSIM_COREVDV_SIM_PREREQ = comp_corev-dv
 endif
 
 # option to use local modelsim.ini file
-ifeq ($(call IS_NO,$(VSIM_LOCAL_MODELSIMINI)),YES)
+ifeq ($(call IS_YES,$(VSIM_LOCAL_MODELSIMINI)),YES)
 gen_corev-dv: VSIM_FLAGS += -modelsimini $(SIM_COREVDV_RESULTS)/modelsim.ini
 run: 					VSIM_FLAGS += -modelsimini modelsim.ini
 endif
@@ -214,8 +214,8 @@ ifeq ($(call IS_YES,$(COV)),YES)
 VOPT_FLAGS  += $(VOPT_COV)
 VSIM_FLAGS  += $(VSIM_COV)
 # VSIM_FLAGS  += -do 'set TEST ${VSIM_TEST}; set TEST_CONFIG $(CFG); set TEST_SEED $(RNDSEED); source $(VSIM_SCRIPT_DIR)/cov.tcl'
-ifneq ($(TEST_CFG_FILE),)
-VSIM_FLAGS  += -do 'setenv TEST_COV ${TEST}; setenv TEST_CONFIG_COV $(CFG); setenv TEST_CFG_FILE_COV _$(TEST_CFG_FILE); setenv TEST_SEED_COV $(RNDSEED); source $(VSIM_SCRIPT_DIR)/cov.tcl'
+ifneq ($(TEST_CFG_FILE_NAME),)
+VSIM_FLAGS  += -do 'setenv TEST_COV ${TEST}; setenv TEST_CONFIG_COV $(CFG); setenv TEST_CFG_FILE_COV _$(TEST_CFG_FILE_NAME); setenv TEST_SEED_COV $(RNDSEED); source $(VSIM_SCRIPT_DIR)/cov.tcl'
 else
 VSIM_FLAGS  += -do 'setenv TEST_COV ${TEST}; setenv TEST_CONFIG_COV $(CFG); setenv TEST_CFG_FILE_COV ""; setenv TEST_SEED_COV $(RNDSEED); source $(VSIM_SCRIPT_DIR)/cov.tcl'
 endif


### PR DESCRIPTION
This PR is for make file changes for TEST_CFG_FILE to add way to support multiple test_cfg yaml for a given test.

Update supports these formats: separated by "," , "+" or space
TEST_CFG_FILE=floating_pt_instr_en,debug_ebreak
TEST_CFG_FILE=floating_pt_instr_en+debug_ebreak
TEST_CFG_FILE="floating_pt_instr_en debug_ebreak"

Only unique yaml test configs will be selected to avoid multiple instances of same yaml. And sorted to ensure uniform dir structure.
