### PR TITLE
TB updates

### DIFF
--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_base_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_base_instr_lib.sv
@@ -80,7 +80,7 @@
   function void randomize_cv32e40p_gpr(cv32e40p_instr instr, riscv_reg_t avail_reg_list[]);
     instr.set_rand_mode();
     `DV_CHECK_RANDOMIZE_WITH_FATAL(instr,
-      if ( (instr.format != (CI_FORMAT || CB_FORMAT || CJ_FORMAT || CR_FORMAT || CA_FORMAT || CL_FORMAT || CS_FORMAT || CSS_FORMAT || CIW_FORMAT)) ) {
+      if ( (format != (CI_FORMAT || CB_FORMAT || CJ_FORMAT || CR_FORMAT || CA_FORMAT || CL_FORMAT || CS_FORMAT || CSS_FORMAT || CIW_FORMAT)) ) {
         if (avail_reg_list.size() > 0) {
           if (has_rs1) {
             rs1 inside {avail_reg_list};
@@ -99,12 +99,18 @@
           if (format == CB_FORMAT) {
             rs1 != reserved_rd[i];
           }
+          if ((category == POST_INC_LOAD) || (category == POST_INC_STORE)) {
+            rs1 != reserved_rd[i];
+          }
         }
         foreach (cfg.reserved_regs[i]) {
           if (has_rd) {
             rd != cfg.reserved_regs[i];
           }
           if (format == CB_FORMAT) {
+            rs1 != cfg.reserved_regs[i];
+          }
+          if ((category == POST_INC_LOAD) || (category == POST_INC_STORE)) {
             rs1 != cfg.reserved_regs[i];
           }
         }
@@ -207,7 +213,7 @@
   function void randomize_zfinx_gpr(riscv_fp_in_x_regs_instr instr, riscv_reg_t avail_reg_list[]);
     instr.set_rand_mode();
     `DV_CHECK_RANDOMIZE_WITH_FATAL(instr,
-      if ( (instr.format != (CI_FORMAT || CB_FORMAT || CJ_FORMAT || CR_FORMAT || CA_FORMAT || CL_FORMAT || CS_FORMAT || CSS_FORMAT || CIW_FORMAT)) ) {
+      if ( (format != (CI_FORMAT || CB_FORMAT || CJ_FORMAT || CR_FORMAT || CA_FORMAT || CL_FORMAT || CS_FORMAT || CSS_FORMAT || CIW_FORMAT)) ) {
         if (avail_reg_list.size() > 0) {
           if (has_rs1) {
             rs1 inside {avail_reg_list};

--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
@@ -1418,7 +1418,7 @@ class cv32e40p_xpulp_hwloop_isa_stress_stream extends cv32e40p_xpulp_hwloop_base
 
           cv32e40p_avail_regs = new[num_of_avail_regs];
           std::randomize(cv32e40p_avail_regs) with {  foreach(cv32e40p_avail_regs[i]) {
-                                                        !(cv32e40p_avail_regs[i] inside {cv32e40p_exclude_regs});
+                                                        !(cv32e40p_avail_regs[i] inside {cv32e40p_exclude_regs, reserved_rd});
                                                    }
                                                 };
 

--- a/cv32e40p/sim/ExternalRepos.mk
+++ b/cv32e40p/sim/ExternalRepos.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40p
 CV_CORE_BRANCH ?= dev
-CV_CORE_HASH   ?= a90f10d5aa65d3663846d225ce06ddadc72e012d
+CV_CORE_HASH   ?= 7e131050c88bd57b2866887eea7de07735f60706
 CV_CORE_TAG    ?= none
 
 # The CV_CORE_HASH above points to version of the RTL that is newer.

--- a/mk/Common.mk
+++ b/mk/Common.mk
@@ -254,7 +254,6 @@ endif
 # test_cfg
 CFGYAML2MAKE = $(CORE_V_VERIF)/bin/cfgyaml2make
 CFG_YAML_PARSE_TARGETS=comp ldgen comp_corev-dv gen_corev-dv test hex clean_hex corev-dv sanity-veri-run bsp riscof_sim_run
-ifneq ($(filter $(CFG_YAML_PARSE_TARGETS),$(MAKECMDGOALS)),)
 ifneq ($(TEST_CFG_FILE),)
 TEST_CFG_FILE_PLUSARGS =
 SPACE_CHAR := $(subst ,, )
@@ -272,8 +271,10 @@ else
 endif
 
 TEST_CFG_FILE_LIST := $(sort $(TEST_CFG_FILE_LIST_TEMP))
-
 TEST_CFG_FILE_NAME = $(subst $(SPACE_CHAR),__,$(TEST_CFG_FILE_LIST))
+
+ifneq ($(filter $(CFG_YAML_PARSE_TARGETS),$(MAKECMDGOALS)),)
+ifneq ($(TEST_CFG_FILE_LIST),)
 
 define GET_TEST_CONFIG_LIST =
 TEST_CFG_LIST_FLAGS_MAKE_$(1) := $$(shell $(CFGYAML2MAKE) --yaml=$(1).yaml $(YAML2MAKE_DEBUG) --prefix=TEST_CFG_FILE_LIST_$(1) --core=$(CV_CORE) --debug)
@@ -292,6 +293,7 @@ $(info [INFO] TEST_CFG dir name $(TEST_CFG_FILE_NAME))
 $(info [INFO] TEST_CFG_FILE plusargs $(TEST_CFG_FILE_PLUSARGS))
 $(info $(BANNER))
 
+endif
 endif
 endif
 


### PR DESCRIPTION
This PR is for some minor fixes in TB:

1.  Update mk/Common.mk to always set TEST_CFG_FILE_NAME with TEST_CFG_FILE
2. Update function randomizing gpr to add constaints for post_inc xpulp instructions
3. Minor fix in 1 hwloop stream to exclude reserved_rd registers
4. Update core hash 