### PR TITLE
Some more fixes from regressions

### DIFF
--- a/cv32e40p/env/corev-dv/custom/isa/riscv_instr.sv
+++ b/cv32e40p/env/corev-dv/custom/isa/riscv_instr.sv
@@ -126,7 +126,7 @@ class riscv_instr extends uvm_object;
           !(cfg.disable_compressed_instr &&
             (instr_inst.group inside {RV32C, RV64C, RV32DC, RV32FC, RV128C})) &&
           !(!cfg.enable_floating_point &&
-            (instr_inst.group inside {RV32F, RV64F, RV32D, RV64D})) &&
+            (instr_inst.group inside {RV32F, RV64F, RV32D, RV64D, RV32DC, RV32FC})) &&
           !(!cfg.enable_vector_extension &&
             (instr_inst.group inside {RVV})) &&
           !(cfg.vector_instr_only &&

--- a/cv32e40p/env/corev-dv/cv32e40p_asm_program_gen.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_asm_program_gen.sv
@@ -440,6 +440,19 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
         instr_stream.push_back(str);
       end
     end
+
+    // Initialize reserved registers for store instr
+    if (!cfg_corev.no_load_store) begin
+      reg_name = cfg_corev.str_rs1.name();
+      reg_val = 32'h80000000; // FIXME : Remove hardcoded value to allow configuration based on linker
+      str = $sformatf("%0sli%0s %0s, 0x%0x", indent, indent, reg_name.tolower(), reg_val);
+      instr_stream.push_back(str);
+
+      reg_name = cfg_corev.str_rs3.name();
+      reg_val = $urandom_range(0,255); // FIXME : include negative also
+      str = $sformatf("%0sli%0s %0s, 0x%0x", indent, indent, reg_name.tolower(), reg_val);
+      instr_stream.push_back(str);
+    end
   endfunction
 
   // Override get_directed_instr_stream for cfg "insert_rand_directed_instr_stream"

--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_base_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_base_instr_lib.sv
@@ -117,6 +117,12 @@
       }
       // TODO: Add constraint for CSR, floating point register
     )
+
+    if (instr.instr_name inside {SB, SH, SW, C_SW, C_FSW, FSW, CV_SB, CV_SH, CV_SW}) begin
+      instr.rs1 = cv32e40p_cfg.str_rs1;
+      instr.rd  = cv32e40p_cfg.str_rs3;
+    end
+
   endfunction
 
   //Function: randomize_cv32e40p_instr_imm()
@@ -236,16 +242,17 @@
             rs1 != reserved_rd[i];
           }
         }
-        foreach (cfg.reserved_regs[i]) {
-          if (has_rd) {
-            rd != cfg.reserved_regs[i];
-          }
-          if (format == CB_FORMAT) {
-            rs1 != cfg.reserved_regs[i];
-          }
-        }
       }
     )
+  endfunction
+
+  // Function to assign reserved reg for store instr from cfg to avoid random
+  // reg operands for stores which may result in corruption of instr memory
+  function void store_instr_gpr_handling(riscv_instr instr);
+    if (instr.instr_name inside {SB, SH, SW, C_SW, C_FSW, FSW, CV_SB, CV_SH, CV_SW}) begin
+      instr.rs1 = cv32e40p_cfg.str_rs1;
+      instr.rd  = cv32e40p_cfg.str_rs3;
+    end
   endfunction
 
 endclass // cv32e40p_base_instr_stream


### PR DESCRIPTION
This PR mainly fixes following:

1.  Random store instructions causing stores to instruction mem region and corrupting the program

-  Add 2 reserved registers just for stores instructions and use them for all store instruction from random stream gneration
- Add these reserved reg to config reserved_regs list to prevent them being used elsewhere 
-  Initialize these reserved reg to a higher mem location. Until we find a better way to randomize it. It will resolve current problem as long as boot_addr is not randomized (we have not planned this use case as of now)

2.  Update pulp streams for ZFINX instruction handling. The randomization was not proper previously. It is resolved now.
3.  Fix issue with RV32FC not getting exluded when enable_floating_point not set