### PR TITLE
skip_sim feature update

### DIFF
--- a/bin/cv_regress
+++ b/bin/cv_regress
@@ -137,11 +137,6 @@ def read_file(args, file):
     for k in testlist['tests']:
         t = testlist['tests'][k]
 
-        try:
-            if args.simulator in t['skip_sim']:
-                continue
-        except KeyError:
-            pass
         test = cv_regression.Test(name=k, simulator=args.simulator, **t)
         if args.cov:
             test.set_cov()
@@ -172,6 +167,16 @@ def read_file(args, file):
             test.num = int(args.num or 1)
         elif test.num != 1:
             test.num = int(args.num or test.num)
+
+        try:
+            if test.simulator in t['skip_sim']:
+                logger.info('Skipping test {} due to selected simulator {}'.format(test.name, test.simulator))
+                continue
+            if test.cfg in t['skip_sim']:
+                logger.info('Skipping test {} due to selected cfg {}'.format(test.name, test.cfg))
+                continue
+        except KeyError:
+            pass
 
         regression.add_test(test)
 

--- a/cv32e40p/regress/cv32e40pv2_benchmarks.yaml
+++ b/cv32e40p/regress/cv32e40pv2_benchmarks.yaml
@@ -16,21 +16,45 @@ builds:
   uvmt_cv32e40p:
     cmd: make comp comp_corev-dv
     dir: cv32e40p/sim/uvmt
-    cfg: pulp
+    cfg: pulp_fpu
 
+# ====================================================================================
 # List of tests
 tests:
-  coremark:
-    build: uvmt_cv32e40p
-    dir: cv32e40p/sim/uvmt
-    cmd: make test TEST=coremark
-
   dhrystone:
     build: uvmt_cv32e40p
+    description: dhrystone
     dir: cv32e40p/sim/uvmt
-    cmd: make test TEST=dhrystone
+    cmd: make test TEST=dhrystone CFG_PLUSARGS="+UVM_TIMEOUT=1000000"
+    num: 1
 
   fibonacci:
     build: uvmt_cv32e40p
+    description: fibonacci
     dir: cv32e40p/sim/uvmt
-    cmd: make test TEST=fibonacci
+    cmd: make test TEST=fibonacci CFG_PLUSARGS="+UVM_TIMEOUT=1000000"
+    num: 1
+
+  coremark:
+    build: uvmt_cv32e40p
+    description: coremark
+    dir: cv32e40p/sim/uvmt
+    cmd: make test TEST=coremark CFG_PLUSARGS="+UVM_TIMEOUT=20000000"
+    num: 1
+
+  matmul_32b_float:
+    build: uvmt_cv32e40p
+    description: matmul_32b_float
+    dir: cv32e40p/sim/uvmt
+    cmd: make test TEST=matmul_32b_float CFG_PLUSARGS="+UVM_TIMEOUT=2000000"
+    num: 1
+    skip_sim:
+      - pulp
+      - pulp_cluster
+
+  matmul_32b_int:
+    build: uvmt_cv32e40p
+    description: matmul_32b_int
+    dir: cv32e40p/sim/uvmt
+    cmd: make test TEST=matmul_32b_int CFG_PLUSARGS="+UVM_TIMEOUT=1000000"
+    num: 1


### PR DESCRIPTION
Generalized the usage of skip_sim to a list of options that prevents the test to be added to the regression, in order to use this inside benchmarks regress.
I added skip_sim for matmul float in benchmark to prevent its addition if cfg has no FPU

That will allow to add a kind of exclude list inside a test item, to avoid unwanted configurations and tests cases. 
For the moment, it is only for cfg, but maybe it could be useful to avoid unwanted test_cfg as well 
