### PR TITLE
pulp and interrupt and debug Regression fixes fro WW37

### DIFF
--- a/cv32e40p/env/corev-dv/cv32e40p_instr_gen_config.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_instr_gen_config.sv
@@ -80,10 +80,15 @@ class cv32e40p_instr_gen_config extends riscv_instr_gen_config;
       dp == ZERO;
     } else {      
       !(dp inside {sp, tp, ra, scratch_reg, GP, RA, ZERO});
-      foreach (gpr[i]) {
-        !(gpr[i] inside {dp});
-      }
     }
+  }
+
+  constraint gpr_c {
+    solve sp, tp, scratch_reg, dp, str_rs1, str_rs3 before gpr;
+    foreach (gpr[i]) {
+      !(gpr[i] inside {sp, tp, scratch_reg, pmp_reg, dp, str_rs1, str_rs3, ZERO, RA, GP});
+    }
+    unique {gpr};
   }
 
   // CV32E40P requires the MTVEC table to be aligned to 256KB boundaries
@@ -164,6 +169,7 @@ class cv32e40p_instr_gen_config extends riscv_instr_gen_config;
     `uvm_field_int(knob_zero_fast_intr_handlers, UVM_DEFAULT)
     `uvm_field_enum(riscv_reg_t, dp, UVM_DEFAULT)
     `uvm_field_enum(riscv_reg_t, scratch_reg, UVM_DEFAULT)
+    `uvm_field_sarray_enum(riscv_reg_t, gpr, UVM_DEFAULT)
     `uvm_field_int(enable_fast_interrupt_handler, UVM_DEFAULT)
     `uvm_field_int(use_fast_intr_handler, UVM_DEFAULT)
     `uvm_field_int(insert_rand_directed_instr_stream, UVM_DEFAULT)

--- a/cv32e40p/regress/cv32e40pv2_interrupt_debug.yaml
+++ b/cv32e40p/regress/cv32e40pv2_interrupt_debug.yaml
@@ -25,77 +25,67 @@ tests:
     build: uvmt_cv32e40p
     description: corev_rand_debug
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug CFG_PLUSARGS="+UVM_TIMEOUT=20000000"
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
 
   corev_rand_debug_ebreak:
     build: uvmt_cv32e40p
     description: corev_rand_debug_ebreak
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak CFG_PLUSARGS="+UVM_TIMEOUT=20000000"
-    test_cfg: debug_ebreak
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
 
   corev_rand_debug_ebreak_xpulp:
     build: uvmt_cv32e40p
     description: corev_rand_debug_ebreak_xpulp
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak_xpulp CFG_PLUSARGS="+UVM_TIMEOUT=20000000"
-    test_cfg: debug_ebreak
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak_xpulp CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
 
   corev_rand_debug_single_step:
     build: uvmt_cv32e40p
     description: corev_rand_debug_single_step
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_single_step CFG_PLUSARGS="+UVM_TIMEOUT=20000000"
-    test_cfg: debug_single_step_en
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_single_step CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
 
   corev_rand_debug_single_step_xpulp:
     build: uvmt_cv32e40p
     description: corev_rand_debug_single_step_xpulp
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_single_step_xpulp CFG_PLUSARGS="+UVM_TIMEOUT=20000000"
-    test_cfg: debug_single_step_en
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_single_step_xpulp CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
 
   corev_rand_interrupt:
     build: uvmt_cv32e40p
     description: corev_rand_interrupt
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt CFG_PLUSARGS="+UVM_TIMEOUT=20000000"
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
 
   corev_rand_interrupt_debug:
     build: uvmt_cv32e40p
     description: corev_rand_interrupt_debug
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_debug CFG_PLUSARGS="+UVM_TIMEOUT=20000000"
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
 
   corev_rand_interrupt_exception:
     build: uvmt_cv32e40p
     description: corev_rand_interrupt_exception
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_exception CFG_PLUSARGS="+UVM_TIMEOUT=20000000"
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_exception CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
 
   corev_rand_interrupt_nested:
     build: uvmt_cv32e40p
     description: corev_rand_interrupt_nested
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_nested CFG_PLUSARGS="+UVM_TIMEOUT=20000000"
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_nested CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
 
   corev_rand_interrupt_wfi:
     build: uvmt_cv32e40p
     description: corev_rand_interrupt_wfi
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi CFG_PLUSARGS="+UVM_TIMEOUT=20000000"
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
 
   corev_rand_interrupt_wfi_mem_stress:
     build: uvmt_cv32e40p
     description: corev_rand_interrupt_wfi_mem_stress
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress CFG_PLUSARGS="+UVM_TIMEOUT=20000000"
-
-  corev_rand_pulp_hwloop_debug:
-    build: uvmt_cv32e40p
-    description: corev_rand_pulp_hwloop_debug
-    dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=20000000"
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
 
   debug_test:
     build: uvmt_cv32e40p
@@ -152,3 +142,74 @@ tests:
     dir: cv32e40p/sim/uvmt
     cmd: make test COREV=YES TEST=riscv_ebreak_test_0 CFG_PLUSARGS="+UVM_TIMEOUT=20000000"
     num: 1
+
+  corev_rand_pulp_instr_ebreak_debug_test:
+    testname: corev_rand_pulp_instr_test
+    description: pulp rand test with ebreak debug
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_test CFG_PLUSARGS="+UVM_TIMEOUT=5000000"
+    test_cfg: debug_ebreak
+
+  corev_rand_pulp_instr_single_step_debug_test:
+    testname: corev_rand_pulp_instr_test
+    description: pulp rand test with single-step debug
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_test CFG_PLUSARGS="+UVM_TIMEOUT=5000000"
+    test_cfg: debug_single_step_en
+
+  corev_rand_pulp_instr_interrupt_test:
+    testname: corev_rand_pulp_instr_test
+    description: pulp instr test with random interrupts
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_test CFG_PLUSARGS="+UVM_TIMEOUT=5000000"
+    test_cfg: gen_rand_int
+
+  corev_rand_pulp_hwloop_debug:
+    build: uvmt_cv32e40p
+    description: hwloop debug random test
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+
+  corev_rand_pulp_hwloop_debug_ebreak:
+    testname: corev_rand_pulp_hwloop_debug
+    description: hwloop ebreak debug random test
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: debug_ebreak
+
+  corev_rand_pulp_hwloop_debug_single_step:
+    testname: corev_rand_pulp_hwloop_debug
+    description: hwloop single-step debug random test
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: debug_single_step_en
+
+  corev_rand_pulp_hwloop_debug_with_interrupt:
+    testname: corev_rand_pulp_hwloop_debug
+    description: hwloop debug with interrupt random test
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: gen_rand_int
+
+  corev_rand_pulp_hwloop_interrupt_test:
+    testname: corev_rand_pulp_hwloop_test
+    description: hwloop test with random interrupts
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_test CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: gen_rand_int
+
+  corev_rand_pulp_hwloop_exception_single_step_debug:
+    testname: corev_rand_pulp_hwloop_exception
+    description: hwloop exception test with single step debug
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: debug_single_step_en
+

--- a/cv32e40p/regress/cv32e40pv2_xpulp_instr.yaml
+++ b/cv32e40p/regress/cv32e40pv2_xpulp_instr.yaml
@@ -28,13 +28,13 @@ tests:
     build: uvmt_cv32e40p
     description: corev_rand_pulp_hwloop_test
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_hwloop_test CFG_PLUSARGS="+UVM_TIMEOUT=1000000"
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_hwloop_test CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
 
   corev_rand_pulp_instr_test:
     build: uvmt_cv32e40p
     description: corev_rand_pulp_instr_test
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_instr_test CFG_PLUSARGS="+UVM_TIMEOUT=1000000"
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_instr_test CFG_PLUSARGS="+UVM_TIMEOUT=5000000"
 
   corev_rand_pulp_simd_instr_test:
     build: uvmt_cv32e40p
@@ -47,6 +47,28 @@ tests:
     description: corev_rand_pulp_mac_instr_test
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_mac_instr_test CFG_PLUSARGS="+UVM_TIMEOUT=1000000"
+
+  corev_rand_pulp_hwloop_exception:
+    build: uvmt_cv32e40p
+    description: hwloop exception test
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+
+  corev_rand_pulp_illegal_instr_test:
+    testname: corev_rand_pulp_instr_test
+    description: pulp instr test with illegal instructions
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_test CFG_PLUSARGS="+UVM_TIMEOUT=5000000"
+    test_cfg: insert_illegal_instr
+
+  corev_rand_pulp_hwloop_illegal_instr_test:
+    testname: corev_rand_pulp_hwloop_test
+    description: hwloop test with illegal instructions
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_test CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: insert_illegal_instr
 
   pulp_hardware_loop:
     build: uvmt_cv32e40p

--- a/cv32e40p/sim/ExternalRepos.mk
+++ b/cv32e40p/sim/ExternalRepos.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40p
 CV_CORE_BRANCH ?= dev
-CV_CORE_HASH   ?= 7e131050c88bd57b2866887eea7de07735f60706
+CV_CORE_HASH   ?= d0f3305c82492f63e7eaad3f6781453de9c4573d
 CV_CORE_TAG    ?= none
 
 # The CV_CORE_HASH above points to version of the RTL that is newer.

--- a/cv32e40p/tests/programs/corev-dv/corev_rand_debug_ebreak_xpulp/corev-dv.yaml
+++ b/cv32e40p/tests/programs/corev-dv/corev_rand_debug_ebreak_xpulp/corev-dv.yaml
@@ -22,3 +22,4 @@ plusargs: >
     +enable_debug_single_step=0
     +gen_debug_section=1
     +test_override_riscv_instr_stream=1
+    +test_override_riscv_instr_sequence=1

--- a/cv32e40p/tests/programs/corev-dv/corev_rand_debug_single_step_xpulp/corev-dv.yaml
+++ b/cv32e40p/tests/programs/corev-dv/corev_rand_debug_single_step_xpulp/corev-dv.yaml
@@ -22,3 +22,4 @@ plusargs: >
     +enable_debug_single_step=1
     +gen_debug_section=1
     +test_override_riscv_instr_stream=1
+    +test_override_riscv_instr_sequence=1

--- a/cv32e40p/tests/programs/corev-dv/corev_rand_pulp_instr_test/corev-dv.yaml
+++ b/cv32e40p/tests/programs/corev-dv/corev_rand_pulp_instr_test/corev-dv.yaml
@@ -33,6 +33,7 @@ plusargs: >
     +no_csr_instr=0
     +no_wfi=1
     +no_dret=1
+    +fix_sp=1
     +enable_misaligned_instr=1
     +test_override_riscv_instr_stream=1
     +test_override_riscv_instr_sequence=1

--- a/cv32e40p/tests/programs/corev-dv/corev_rand_pulp_mac_instr_test/corev-dv.yaml
+++ b/cv32e40p/tests/programs/corev-dv/corev_rand_pulp_mac_instr_test/corev-dv.yaml
@@ -30,6 +30,7 @@ plusargs: >
     +no_wfi=1
     +no_ebreak=1
     +no_dret=1
+    +fix_sp=1
     +enable_misaligned_instr=1
     +set_dcsr_ebreak=0
     +test_override_riscv_instr_stream=1

--- a/cv32e40p/tests/programs/corev-dv/corev_rand_pulp_simd_instr_test/corev-dv.yaml
+++ b/cv32e40p/tests/programs/corev-dv/corev_rand_pulp_simd_instr_test/corev-dv.yaml
@@ -30,6 +30,7 @@ plusargs: >
     +no_wfi=1
     +no_ebreak=1
     +no_dret=1
+    +fix_sp=1
     +enable_misaligned_instr=1
     +set_dcsr_ebreak=0
     +test_override_riscv_instr_stream=1

--- a/cv32e40p/tests/test_cfg/obi_zero_latency.yaml
+++ b/cv32e40p/tests/test_cfg/obi_zero_latency.yaml
@@ -1,0 +1,5 @@
+name: Fixed zero latency for both obi buses
+description: >
+    Obi bus latency config - Zero delay
+plusargs: >
+    +rand_stall_obi_disable


### PR DESCRIPTION
This PR is related to fixes for issues seen during regressions for pulp and interrupt-debug

1.  override constraint in config item for gpr to include all reserved regs. this fixes issue of gpr getting SP reg and corrupting some code
2. fix issue in pulp random tests with missing test_override_riscv_instr_sequence 
3. Add fix_sp= 1plusarg in corev-dv pulp random tests to set SP=x2 for these tests to be able to include compresses load/stores with SP instructions as for these need SP=x2. SP randomization to be handled in a separate test later.
4. add new test_cfg yaml for zeri obi delay latency
5. update pulp , interrupt and debug regress yaml for various updates - adjusting timout (increase where needed) , add new tests