### PR TITLE
Fix issues with corev_rand_pulp_hwloop_exception test

### DIFF
--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
@@ -1513,7 +1513,10 @@ class cv32e40p_xpulp_hwloop_exception extends cv32e40p_xpulp_hwloop_base_stream;
       //Exclude list for all random instruction generation part
       riscv_exclude_common_instr = {CV_START, CV_STARTI, CV_END, CV_ENDI, CV_COUNT, CV_COUNTI, CV_SETUP, CV_SETUPI,
                                     CV_ELW,
-                                    JAL, C_J, C_JAL};
+                                    C_ADDI16SP,
+                                    WFI,
+                                    URET, SRET, MRET, DRET,
+                                    JALR, JAL, C_JR, C_JALR, C_J, C_JAL };
       super.post_randomize();
       this.print();
   endfunction : post_randomize
@@ -1602,6 +1605,9 @@ class cv32e40p_xpulp_hwloop_exception extends cv32e40p_xpulp_hwloop_base_stream;
 
       if(no_compressed)
           riscv_exclude_group = {riscv_exclude_group, RV32C, RV32FC};
+
+      if(no_branch)
+          riscv_exclude_instr = {riscv_exclude_instr, BEQ, BNE, BLT, BGE, BLTU, BGEU, C_BEQZ, C_BNEZ, CV_BEQIMM, CV_BNEIMM};
 
       `uvm_info("cv32e40p_xpulp_hwloop_base_stream",
                  $sformatf("insert_rand_instr- Number of Random instr to generate= %0d",num_rand_instr),

--- a/cv32e40p/regress/cv32e40pv2_interrupt_debug.yaml
+++ b/cv32e40p/regress/cv32e40pv2_interrupt_debug.yaml
@@ -210,6 +210,6 @@ tests:
     description: hwloop exception test with single step debug
     build: uvmt_cv32e40p
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=3000000"
     test_cfg: debug_single_step_en
 

--- a/cv32e40p/regress/cv32e40pv2_xpulp_instr.yaml
+++ b/cv32e40p/regress/cv32e40pv2_xpulp_instr.yaml
@@ -52,7 +52,7 @@ tests:
     build: uvmt_cv32e40p
     description: hwloop exception test
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=1000000"
 
   corev_rand_pulp_illegal_instr_test:
     testname: corev_rand_pulp_instr_test


### PR DESCRIPTION
Minor fixes for this test to fix test hang issues and also reduce the timeout for this test in regress list