### PR TITLE
Some fixes for issues in regression

### DIFF
--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
@@ -154,10 +154,10 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
       num_loops_active inside {1,2,3};
 
       foreach(hwloop_counti[i])
-          hwloop_counti[i] inside {[0:200]};//TODO: check 0 is valid
+          hwloop_counti[i] inside {[0:100]};//TODO: check 0 is valid
 
       foreach(hwloop_count[i])
-          hwloop_count[i] inside {[0:200]};//TODO: check 0 is valid
+          hwloop_count[i] inside {[0:100]};//TODO: check 0 is valid
   }
 
   constraint num_hwloop_instr_c {
@@ -1541,6 +1541,12 @@ class cv32e40p_xpulp_hwloop_exception extends cv32e40p_xpulp_hwloop_base_stream;
       if(no_compressed)
           riscv_exclude_group = {riscv_exclude_group, RV32C, RV32FC};
 
+      if(no_branch)
+          riscv_exclude_instr = {riscv_exclude_instr, BEQ, BNE, BLT, BGE, BLTU, BGEU, C_BEQZ, C_BNEZ, CV_BEQIMM, CV_BNEIMM};
+
+      if(no_fence)
+          riscv_exclude_instr = {riscv_exclude_instr, FENCE, FENCE_I};
+
       riscv_exclude_xpulp = {riscv_exclude_group, RV32X};
 
       //Create and Randomize array for avail_regs each time to ensure randomization
@@ -1608,6 +1614,9 @@ class cv32e40p_xpulp_hwloop_exception extends cv32e40p_xpulp_hwloop_base_stream;
 
       if(no_branch)
           riscv_exclude_instr = {riscv_exclude_instr, BEQ, BNE, BLT, BGE, BLTU, BGEU, C_BEQZ, C_BNEZ, CV_BEQIMM, CV_BNEIMM};
+
+      if(no_fence)
+          riscv_exclude_instr = {riscv_exclude_instr, FENCE, FENCE_I};
 
       `uvm_info("cv32e40p_xpulp_hwloop_base_stream",
                  $sformatf("insert_rand_instr- Number of Random instr to generate= %0d",num_rand_instr),

--- a/cv32e40p/regress/cv32e40pv2_interrupt_debug.yaml
+++ b/cv32e40p/regress/cv32e40pv2_interrupt_debug.yaml
@@ -25,67 +25,72 @@ tests:
     build: uvmt_cv32e40p
     description: corev_rand_debug
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug CFG_PLUSARGS="+UVM_TIMEOUT=2000000"
 
   corev_rand_debug_ebreak:
     build: uvmt_cv32e40p
     description: corev_rand_debug_ebreak
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak CFG_PLUSARGS="+UVM_TIMEOUT=2000000"
 
   corev_rand_debug_ebreak_xpulp:
     build: uvmt_cv32e40p
     description: corev_rand_debug_ebreak_xpulp
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak_xpulp CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    num: 1
 
   corev_rand_debug_single_step:
     build: uvmt_cv32e40p
     description: corev_rand_debug_single_step
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_single_step CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    num: 1
 
   corev_rand_debug_single_step_xpulp:
     build: uvmt_cv32e40p
     description: corev_rand_debug_single_step_xpulp
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_single_step_xpulp CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    num: 1
 
   corev_rand_interrupt:
     build: uvmt_cv32e40p
     description: corev_rand_interrupt
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    num: 1
 
   corev_rand_interrupt_debug:
     build: uvmt_cv32e40p
     description: corev_rand_interrupt_debug
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_debug CFG_PLUSARGS="+UVM_TIMEOUT=2000000"
 
   corev_rand_interrupt_exception:
     build: uvmt_cv32e40p
     description: corev_rand_interrupt_exception
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_exception CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_exception CFG_PLUSARGS="+UVM_TIMEOUT=2000000"
 
   corev_rand_interrupt_nested:
     build: uvmt_cv32e40p
     description: corev_rand_interrupt_nested
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_nested CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    num: 1
 
   corev_rand_interrupt_wfi:
     build: uvmt_cv32e40p
     description: corev_rand_interrupt_wfi
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi CFG_PLUSARGS="+UVM_TIMEOUT=2000000"
 
   corev_rand_interrupt_wfi_mem_stress:
     build: uvmt_cv32e40p
     description: corev_rand_interrupt_wfi_mem_stress
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress CFG_PLUSARGS="+UVM_TIMEOUT=2000000"
 
   debug_test:
     build: uvmt_cv32e40p

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_imperas_dv_wrap.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_imperas_dv_wrap.sv
@@ -455,8 +455,8 @@ module uvmt_cv32e40p_imperas_dv_wrap
 
     // Select processor name
     void'(rvviRefConfigSetString(IDV_CONFIG_MODEL_NAME, "CV32E40P"));
-    // Worst case propagation of events 4 retirements (actually 3 observed)
-    void'(rvviRefConfigSetInt(IDV_CONFIG_MAX_NET_LATENCY_RETIREMENTS, 4));
+    // Worst case propagation of events 14 retirements (14 due to long fpu multicycle instr)
+    void'(rvviRefConfigSetInt(IDV_CONFIG_MAX_NET_LATENCY_RETIREMENTS, 14));
     // Redirect stdout to parent systemverilog simulator
     void'(rvviRefConfigSetInt(IDV_CONFIG_REDIRECT_STDOUT, RVVI_TRUE));
 


### PR DESCRIPTION
1.  change Imperas config IDV_CONFIG_MAX_NET_LATENCY_RETIREMENTS to 14 due to long latency F instructions like fdiv and fsqrt
2. set num=1 in interrupt_debug regress for long running corev-dv tests with intention to move these to a separate list
3. update hwloop streams to a lower max loop count config and remove fence/branch instructions frm exception stream. As these are expected to be flagged by toolchain.