### PR TITLE
PR for corev_dv and tests support for debug trigger and update illegal instruction gen for corev_dv

### DIFF
--- a/cv32e40p/env/corev-dv/cv32e40p_asm_program_gen.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_asm_program_gen.sv
@@ -550,6 +550,9 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
 
   // Override Illegal instruction handler - gen_illegal_instr_handler
   // Replace pop_gpr_from_kernel_stack with pop_regfile_from_kernel_stack
+  // With RV32X enabled, check for illegal instr on the last instr of hwloop
+  // If true, then set MEPC to first instr of hwloop instead of simply
+  // incrementing by 4.
   virtual function void gen_illegal_instr_handler(int hart);
     string instr[$];
     cv32e40p_instr_gen_config corev_cfg;
@@ -558,11 +561,38 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
 
     gen_signature_handshake(instr, CORE_STATUS, ILLEGAL_INSTR_EXCEPTION);
     gen_signature_handshake(.instr(instr), .signature_type(WRITE_CSR), .csr(MCAUSE));
-    instr = {instr,
-            $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[0], MEPC),
-            $sformatf("addi  x%0d, x%0d, 4", cfg.gpr[0], cfg.gpr[0]),
-            $sformatf("csrw  0x%0x, x%0d", MEPC, cfg.gpr[0])
-    };
+    if (riscv_instr_pkg::RV32X inside {riscv_instr_pkg::supported_isa}) begin
+      instr = {instr,
+              $sformatf("csrr x%0d, 0x%0x", cfg.gpr[0], LPCOUNT1),
+              $sformatf("li x%0d, 2", cfg.gpr[1]),
+              $sformatf("bge x%0d, x%0d, 1f", cfg.gpr[0], cfg.gpr[1]),
+              $sformatf("2: csrr x%0d, 0x%0x", cfg.gpr[0], LPCOUNT0),
+              $sformatf("li x%0d, 2", cfg.gpr[1]),
+              $sformatf("bge x%0d, x%0d, 3f", cfg.gpr[0], cfg.gpr[1]),
+              $sformatf("beqz x0, 4f"),
+              $sformatf("1: csrr  x%0d, 0x%0x", cfg.gpr[0], MEPC),
+              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[1], LPEND1),
+              $sformatf("addi x%0d, x%0d, -4", cfg.gpr[1], cfg.gpr[1]),
+              $sformatf("bne x%0d, x%0d, 2b", cfg.gpr[0], cfg.gpr[1]),
+              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[0], LPSTART1),
+              $sformatf("beqz x0, 5f"),
+              $sformatf("3: csrr  x%0d, 0x%0x", cfg.gpr[0], MEPC),
+              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[1], LPEND0),
+              $sformatf("addi x%0d, x%0d, -4", cfg.gpr[1], cfg.gpr[1]),
+              $sformatf("bne x%0d, x%0d, 4f", cfg.gpr[0], cfg.gpr[1]),
+              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[0], LPSTART0),
+              $sformatf("beqz x0, 5f"),
+              $sformatf("4: csrr  x%0d, 0x%0x", cfg.gpr[0], MEPC),
+              $sformatf("addi  x%0d, x%0d, 4", cfg.gpr[0], cfg.gpr[0]),
+              $sformatf("5: csrw  0x%0x, x%0d", MEPC, cfg.gpr[0])
+      };
+    end else begin
+      instr = {instr,
+              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[0], MEPC),
+              $sformatf("addi  x%0d, x%0d, 4", cfg.gpr[0], cfg.gpr[0]),
+              $sformatf("csrw  0x%0x, x%0d", MEPC, cfg.gpr[0])
+      };
+    end
     // Replace pop_gpr_from_kernel_stack with pop_regfile_from_kernel_stack
     //pop_gpr_from_kernel_stack(MSTATUS, MSCRATCH, cfg.mstatus_mprv, cfg.sp, cfg.tp, instr);
     pop_regfile_from_kernel_stack(MSTATUS, MSCRATCH, cfg.mstatus_mprv, cfg.sp, cfg.tp, instr, corev_cfg);

--- a/cv32e40p/env/corev-dv/cv32e40p_debug_rom_gen.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_debug_rom_gen.sv
@@ -18,6 +18,7 @@
 //
 class cv32e40p_debug_rom_gen extends riscv_debug_rom_gen;
     string debug_dret[$];
+    cv32e40p_instr_gen_config cfg_corev;
 
     `uvm_object_utils(cv32e40p_debug_rom_gen)
 
@@ -27,17 +28,16 @@ class cv32e40p_debug_rom_gen extends riscv_debug_rom_gen;
 
     virtual function void gen_program();
         string sub_program_name[$] = {};
-        cv32e40p_instr_gen_config cfg_corev;
         privileged_reg_t status = MSTATUS;
+
+        if(!uvm_config_db#(cv32e40p_instr_gen_config)::get(null,get_full_name(),"cv32e40p_instr_cfg", cfg_corev)) begin
+          `uvm_fatal(get_full_name(), "Cannot get cv32e40p_instr_gen_config")
+        end
 
         // CORE-V Addition
         // Insert section info so linker can place
         // debug code at the correct adress        
         instr_stream.push_back(".section .debugger, \"ax\"");
-
-        // CORE-V Addition
-        // Cast CORE-V derived handle to enable fetching core-v config fields
-        `DV_CHECK($cast(cfg_corev, cfg))
 
         // Randomly add a WFI at start of ddebug rom
         // This will be treaed as a NOP always, but added here to close instructon

--- a/cv32e40p/env/corev-dv/cv32e40p_illegal_instr.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_illegal_instr.sv
@@ -39,6 +39,18 @@ class cv32e40p_illegal_instr extends riscv_illegal_instr;
 
   function new(string name="");
     super.new(name);
-  endfunction  
+  endfunction
+
+  function void cv32e40p_init(riscv_instr_gen_config cfg);
+    this.cfg = cfg;
+    if (riscv_instr_pkg::RV32ZFINX inside {riscv_instr_pkg::supported_isa}) begin
+      legal_opcode = {legal_opcode, 7'b1000011, 7'b1000111, 7'b1001011,
+                                    7'b1001111, 7'b1010011};
+    end
+    if (riscv_instr_pkg::RV32X inside {riscv_instr_pkg::supported_isa}) begin
+      legal_opcode = {legal_opcode, 7'b0001011, 7'b0101011, 7'b1011011,
+                                    7'b1111011};
+    end
+  endfunction
 
 endclass : cv32e40p_illegal_instr

--- a/cv32e40p/env/corev-dv/cv32e40p_instr_gen_config.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_instr_gen_config.sv
@@ -59,6 +59,23 @@ class cv32e40p_instr_gen_config extends riscv_instr_gen_config;
   rand riscv_reg_t  str_rs1;
   rand riscv_reg_t  str_rs3;
 
+  // Enable debug trigger breakpoint setup in debug rom
+  bit setup_debug_trigger_on_addr_match = 0;
+
+  // Number of trigger iterations in a given test
+  rand int trigger_iterations;
+
+  // Random offset to program next trigger address
+  rand int trigger_addr_offset;
+
+  //random field to enable setting of single stepping only after
+  //a trigger breakpoint causes debug entry
+  rand bit debug_trigger_before_single_step;
+
+  //random field to enable setting of single stepping only after
+  //an ebreak causes debug entry
+  rand bit debug_ebreak_before_single_step;
+
   constraint ss_dbg_high_iteration_cnt_c {
     ss_dbg_high_iteration_cnt dist {0 := 60, 1 := 40};
   }
@@ -164,6 +181,12 @@ class cv32e40p_instr_gen_config extends riscv_instr_gen_config;
     }
   }
 
+  constraint trigger_c {
+    trigger_iterations inside {[1:10]};
+    trigger_addr_offset inside {[4:100]};
+    trigger_addr_offset % 4 == 0;
+  }
+
   `uvm_object_utils_begin(cv32e40p_instr_gen_config)
     `uvm_field_enum(mtvec_mode_t, mtvec_mode, UVM_DEFAULT)
     `uvm_field_int(knob_zero_fast_intr_handlers, UVM_DEFAULT)
@@ -181,6 +204,11 @@ class cv32e40p_instr_gen_config extends riscv_instr_gen_config;
     `uvm_field_int(xpulp_instr_in_debug_rom, UVM_DEFAULT)
     `uvm_field_enum(riscv_reg_t, str_rs1, UVM_DEFAULT)
     `uvm_field_enum(riscv_reg_t, str_rs3, UVM_DEFAULT)
+    `uvm_field_int(setup_debug_trigger_on_addr_match, UVM_DEFAULT)
+    `uvm_field_int(trigger_iterations, UVM_DEFAULT)
+    `uvm_field_int(trigger_addr_offset, UVM_DEFAULT)
+    `uvm_field_int(debug_trigger_before_single_step, UVM_DEFAULT)
+    `uvm_field_int(debug_ebreak_before_single_step, UVM_DEFAULT)
   `uvm_object_utils_end
 
   function new(string name="");
@@ -190,6 +218,13 @@ class cv32e40p_instr_gen_config extends riscv_instr_gen_config;
     get_bool_arg_value("+insert_rand_directed_instr_stream=", insert_rand_directed_instr_stream);
     get_int_arg_value("+test_rand_directed_instr_stream_num=", test_rand_directed_instr_stream_num);
     get_bool_arg_value("+is_hwloop_test=", is_hwloop_test);
+    get_bool_arg_value("+setup_debug_trigger_on_addr_match=", setup_debug_trigger_on_addr_match);
+    get_bool_arg_value("+debug_trigger_before_single_step=", debug_trigger_before_single_step);
+    get_bool_arg_value("+debug_ebreak_before_single_step=", debug_ebreak_before_single_step);
+
+    if ($test$plusargs("debug_trigger_before_single_step")) debug_trigger_before_single_step.rand_mode(0);
+    if ($test$plusargs("debug_ebreak_before_single_step")) debug_ebreak_before_single_step.rand_mode(0);
+
   endfunction : new
 
   function void post_randomize();

--- a/cv32e40p/env/corev-dv/cv32e40p_instr_pkg.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_instr_pkg.sv
@@ -1,0 +1,36 @@
+//
+// Copyright 2023 OpenHW Group
+// Copyright 2023 Dolphin Design
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+//****************************************************************************************************************
+
+
+package cv32e40p_instr_pkg;
+
+ typedef enum bit [11:0] {
+    // User Custom CSRs
+    LPSTART0        = 'hCC0,  // Hardware Loop 0 Start
+    LPEND0          = 'hCC1,  // Hardware Loop 0 End
+    LPCOUNT0        = 'hCC2,  // Hardware Loop 0 Counter
+    LPSTART1        = 'hCC4,  // Hardware Loop 1 Start
+    LPEND1          = 'hCC5,  // Hardware Loop 1 End
+    LPCOUNT1        = 'hCC6,  // Hardware Loop 1 Counter
+    UHARTID         = 'hCD0,  // Hardware Thread ID
+    PRIVLV          = 'hCD1,  // Privilege Level
+    ZFINX           = 'hCD2   // ZFINX ISA
+  } custom_csr_reg_t;
+
+endpackage

--- a/cv32e40p/env/corev-dv/cv32e40p_instr_test_pkg.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_instr_test_pkg.sv
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 
+`include "cv32e40p_instr_pkg.sv"
+
 package cv32e40p_instr_test_pkg;
 
   parameter int HWLOOP_LABEL_STR_LEN = 32;
 
   import uvm_pkg::*;
   import riscv_instr_pkg::*;
+  import cv32e40p_instr_pkg::*;
   import riscv_instr_test_pkg::*;
   import riscv_signature_pkg::*;
   import corev_instr_test_pkg::*;

--- a/cv32e40p/env/corev-dv/cv32e40p_instr_test_pkg.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_instr_test_pkg.sv
@@ -34,9 +34,9 @@ package cv32e40p_instr_test_pkg;
 
   // RISCV-DV class override definitions
   `include "cv32e40p_rand_instr_stream.sv"
+  `include "cv32e40p_illegal_instr.sv"
   `include "cv32e40p_instr_sequence.sv"
   `include "cv32e40p_compressed_instr.sv"
-  `include "cv32e40p_illegal_instr.sv"
   `include "cv32e40p_privil_reg.sv"
   `include "cv32e40p_debug_rom_gen.sv"
   `include "cv32e40p_asm_program_gen.sv"

--- a/cv32e40p/env/corev-dv/cv32e40p_rand_instr_stream.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_rand_instr_stream.sv
@@ -164,12 +164,12 @@ class cv32e40p_rand_instr_stream extends riscv_rand_instr_stream;
     //Use this plusarg - include_xpulp_instr_in_debug_rom to include xpulp instr
     //In random debug_rom instructions. Added for v2 debug tests with xpulp.
     if (cv32e40p_cfg.xpulp_instr_in_debug_rom && is_debug_program && $test$plusargs("include_xpulp_instr_in_debug_rom")) begin
+        `uvm_info("cv32e40p_rand_instr_stream", $sformatf("Including xpulp instr in debug_rom"), UVM_LOW)
         foreach(instr_list[i]) begin
           randcase
             1: randomize_debug_rom_instr(.instr(instr_list[i]), .is_in_debug(is_debug_program), .disable_dist());
             2: randomize_instr(instr_list[i], is_debug_program);
           endcase
-          `uvm_info("cv32e40p_rand_instr_stream", $sformatf("include_xpulp_instr_in_debug_rom set- Including xpulp instr in debug_rom"), UVM_LOW)
         end
     end
     else begin

--- a/cv32e40p/env/uvme/vseq/uvme_cv32e40p_random_debug_vseq.sv
+++ b/cv32e40p/env/uvme/vseq/uvme_cv32e40p_random_debug_vseq.sv
@@ -73,11 +73,12 @@ class uvme_cv32e40p_reduced_rand_debug_req_c extends uvme_cv32e40p_random_debug_
     }
 
     constraint num_dgb_req_c {
-        num_of_debug_req inside {[1:3]};
+        num_of_debug_req inside {[1:5]};
     }
 
     extern function new(string name="uvme_cv32e40p_reduced_rand_debug_req");
     extern virtual task body();
+    extern virtual task rand_delay();
 endclass : uvme_cv32e40p_reduced_rand_debug_req_c
 
 function uvme_cv32e40p_reduced_rand_debug_req_c::new(string name="uvme_cv32e40p_reduced_rand_debug_req");
@@ -86,6 +87,12 @@ function uvme_cv32e40p_reduced_rand_debug_req_c::new(string name="uvme_cv32e40p_
         num_of_debug_req.rand_mode(0);
     end
 endfunction : new
+
+task uvme_cv32e40p_reduced_rand_debug_req_c::rand_delay();
+    std::randomize(dly) with {  dly inside {[1:10000]};
+                             };
+    #(dly);
+endtask : rand_delay
 
 task uvme_cv32e40p_reduced_rand_debug_req_c::body();
     for (int i = 1; i <= num_of_debug_req; i++) begin

--- a/cv32e40p/regress/cv32e40pv2_interrupt_debug.yaml
+++ b/cv32e40p/regress/cv32e40pv2_interrupt_debug.yaml
@@ -26,12 +26,14 @@ tests:
     description: corev_rand_debug
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug CFG_PLUSARGS="+UVM_TIMEOUT=2000000"
+    num: 1
 
   corev_rand_debug_ebreak:
     build: uvmt_cv32e40p
     description: corev_rand_debug_ebreak
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak CFG_PLUSARGS="+UVM_TIMEOUT=2000000"
+    num: 1
 
   corev_rand_debug_ebreak_xpulp:
     build: uvmt_cv32e40p
@@ -91,6 +93,7 @@ tests:
     description: corev_rand_interrupt_wfi_mem_stress
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress CFG_PLUSARGS="+UVM_TIMEOUT=2000000"
+    num: 1
 
   debug_test:
     build: uvmt_cv32e40p
@@ -164,6 +167,14 @@ tests:
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_test CFG_PLUSARGS="+UVM_TIMEOUT=5000000"
     test_cfg: debug_single_step_en
 
+  corev_rand_pulp_instr_debug_trigger_test:
+    testname: corev_rand_pulp_instr_test
+    description: pulp rand test with debug trigger
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_test CFG_PLUSARGS="+UVM_TIMEOUT=5000000"
+    test_cfg: debug_trigger_basic
+
   corev_rand_pulp_instr_interrupt_test:
     testname: corev_rand_pulp_instr_test
     description: pulp instr test with random interrupts
@@ -194,6 +205,30 @@ tests:
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
     test_cfg: debug_single_step_en
 
+  corev_rand_pulp_hwloop_debug_trigger:
+    testname: corev_rand_pulp_hwloop_debug
+    description: hwloop debug random test with debug trigger on instr addr match
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: debug_trigger_basic
+
+  corev_rand_pulp_hwloop_debug_trigger_with_ebreak:
+    testname: corev_rand_pulp_hwloop_debug
+    description: hwloop debug random test with debug trigger and ebreak
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: debug_trigger_basic,debug_ebreak
+
+  corev_rand_pulp_hwloop_debug_trigger_with_single_step:
+    testname: corev_rand_pulp_hwloop_debug
+    description: hwloop debug random test with debug trigger and single step
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: debug_trigger_basic,debug_single_step_en
+
   corev_rand_pulp_hwloop_debug_with_interrupt:
     testname: corev_rand_pulp_hwloop_debug
     description: hwloop debug with interrupt random test
@@ -201,6 +236,22 @@ tests:
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
     test_cfg: gen_rand_int
+
+  corev_rand_pulp_hwloop_debug_with_int_debug_trigger:
+    testname: corev_rand_pulp_hwloop_debug
+    description: hwloop debug with interrupt and debug trigger random test
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: gen_rand_int,debug_trigger_basic
+
+  corev_rand_pulp_hwloop_debug_with_int_debug_trigger_single_step:
+    testname: corev_rand_pulp_hwloop_debug
+    description: hwloop debug with interrupt, debug trigger and single step random test
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: gen_rand_int,debug_trigger_basic,debug_single_step_en
 
   corev_rand_pulp_hwloop_interrupt_test:
     testname: corev_rand_pulp_hwloop_test
@@ -217,4 +268,20 @@ tests:
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=3000000"
     test_cfg: debug_single_step_en
+
+  corev_rand_pulp_hwloop_exception_debug_trigger:
+    testname: corev_rand_pulp_hwloop_exception
+    description: hwloop exception test with debug trigger
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=3000000"
+    test_cfg: debug_trigger_basic
+
+  corev_rand_pulp_hwloop_exception_with_int_debug_trigger:
+    testname: corev_rand_pulp_hwloop_exception
+    description: hwloop exception test with interrupt and debug trigger
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=3000000"
+    test_cfg: gen_rand_int,debug_trigger_basic
 

--- a/cv32e40p/regress/cv32e40pv2_interrupt_debug_short.yaml
+++ b/cv32e40p/regress/cv32e40pv2_interrupt_debug_short.yaml
@@ -55,6 +55,14 @@ tests:
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_test CFG_PLUSARGS="+UVM_TIMEOUT=5000000"
     test_cfg: debug_single_step_en
 
+  corev_rand_pulp_instr_debug_trigger_test:
+    testname: corev_rand_pulp_instr_test
+    description: pulp rand test with debug trigger
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_test CFG_PLUSARGS="+UVM_TIMEOUT=5000000"
+    test_cfg: debug_trigger_basic
+
   corev_rand_pulp_instr_interrupt_test:
     testname: corev_rand_pulp_instr_test
     description: pulp instr test with random interrupts
@@ -85,6 +93,30 @@ tests:
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
     test_cfg: debug_single_step_en
 
+  corev_rand_pulp_hwloop_debug_trigger:
+    testname: corev_rand_pulp_hwloop_debug
+    description: hwloop debug random test with debug trigger on instr addr match
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: debug_trigger_basic
+
+  corev_rand_pulp_hwloop_debug_trigger_with_ebreak:
+    testname: corev_rand_pulp_hwloop_debug
+    description: hwloop debug random test with debug trigger and ebreak
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: debug_trigger_basic,debug_ebreak
+
+  corev_rand_pulp_hwloop_debug_trigger_with_single_step:
+    testname: corev_rand_pulp_hwloop_debug
+    description: hwloop debug random test with debug trigger and single step
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: debug_trigger_basic,debug_single_step_en
+
   corev_rand_pulp_hwloop_debug_with_interrupt:
     testname: corev_rand_pulp_hwloop_debug
     description: hwloop debug with interrupt random test
@@ -92,6 +124,22 @@ tests:
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
     test_cfg: gen_rand_int
+
+  corev_rand_pulp_hwloop_debug_with_int_debug_trigger:
+    testname: corev_rand_pulp_hwloop_debug
+    description: hwloop debug with interrupt and debug trigger random test
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: gen_rand_int,debug_trigger_basic
+
+  corev_rand_pulp_hwloop_debug_with_int_debug_trigger_single_step:
+    testname: corev_rand_pulp_hwloop_debug
+    description: hwloop debug with interrupt, debug trigger and single step random test
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: gen_rand_int,debug_trigger_basic,debug_single_step_en
 
   corev_rand_pulp_hwloop_interrupt_test:
     testname: corev_rand_pulp_hwloop_test
@@ -108,6 +156,22 @@ tests:
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=3000000"
     test_cfg: debug_single_step_en
+
+  corev_rand_pulp_hwloop_exception_debug_trigger:
+    testname: corev_rand_pulp_hwloop_exception
+    description: hwloop exception test with debug trigger
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=3000000"
+    test_cfg: debug_trigger_basic
+
+  corev_rand_pulp_hwloop_exception_with_int_debug_trigger:
+    testname: corev_rand_pulp_hwloop_exception
+    description: hwloop exception test with interrupt and debug trigger
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=3000000"
+    test_cfg: gen_rand_int,debug_trigger_basic
 
   debug_test:
     build: uvmt_cv32e40p

--- a/cv32e40p/tests/programs/corev-dv/corev_rand_pulp_hwloop_debug/corev-dv.yaml
+++ b/cv32e40p/tests/programs/corev-dv/corev_rand_pulp_hwloop_debug/corev-dv.yaml
@@ -8,7 +8,7 @@ uvm_test: $(CV_CORE_LC)_instr_base_test
 description: >
     RISCV-DV generated random hwloop test with random debug
 plusargs: >
-    +instr_cnt=1000
+    +instr_cnt=200
     +num_of_sub_program=0
     +insert_rand_directed_instr_stream=1
     +test_rand_directed_instr_stream_num=6

--- a/cv32e40p/tests/programs/corev-dv/corev_rand_pulp_hwloop_debug/test.yaml
+++ b/cv32e40p/tests/programs/corev-dv/corev_rand_pulp_hwloop_debug/test.yaml
@@ -8,4 +8,3 @@ description: >
     Random debug in xpulp hwloop stream
 plusargs: >
     +gen_reduced_rand_dbg_req
-    +num_debug_req=2

--- a/cv32e40p/tests/test_cfg/debug_trigger_basic.yaml
+++ b/cv32e40p/tests/test_cfg/debug_trigger_basic.yaml
@@ -1,0 +1,7 @@
+name: debug_trigger_basic
+description: >
+    Use debug trigger with instr address
+plusargs: >
+    +no_dret=1
+    +setup_debug_trigger_on_addr_match=1
+    +gen_debug_section=1


### PR DESCRIPTION
Work done in this PR:

1. Update cv32e40p corev_dv files to support random debug trigger generation as part of random tests
2. Added new test_cfg yaml file debug_trigger_basic
3. Update cv32e40pv2 interrupt_debug regress yaml files for new random trigger corev_dv tests with pulp and hwloop streams
4. Improve existing hwloop_debug test for better randomization and coverage
5. Add cv32e40p related legal opcodes to support zfinx and rv32x extensions
6. Update cv32e40p_instr_sequence to use new cv32e40p_insert_illegal_hint_instr function to inject illegal instructions. The update now excludes legal rv32x/zfinx opcodes as part of illegal instruction generation.

7. Update illegal instr handler to check for hwloop execution and calculate MEPC accordingly