### PR TITLE
Fixes from regression for hwloop and interrupt /debug tests

### DIFF
--- a/cv32e40p/env/corev-dv/cv32e40p_asm_program_gen.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_asm_program_gen.sv
@@ -365,9 +365,6 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
     // Restore user mode GPR value from kernel stack before return
 
     // Replace pop_gpr_from_kernel_stack with pop_regfile_from_kernel_stack
-    //pop_gpr_from_kernel_stack(status, scratch, cfg.mstatus_mprv,
-    //                          cfg.sp, cfg.tp, interrupt_handler_instr);
-
     pop_regfile_from_kernel_stack(status, scratch, cfg.mstatus_mprv,
                               cfg.sp, cfg.tp, interrupt_handler_instr, corev_cfg);
                                       // Emit fast interrupt handler since cv32e40p has hardware interrupt ack
@@ -526,8 +523,59 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
     instr_stream.push_back(str);
   endfunction
 
+  // Override ECALL trap handler - gen_ecall_handler of corev-dv
+  // Replace pop_gpr_from_kernel_stack with pop_regfile_from_kernel_stack
+  // With RV32X enabled, check for illegal instr on the last instr of hwloop
+  // If true, then set MEPC to first instr of hwloop instead of simply
+  // incrementing by 4.
+  virtual function void gen_ecall_handler(int hart);
+    string instr[$];
+    cv32e40p_instr_gen_config corev_cfg;
+
+    `DV_CHECK_FATAL($cast(corev_cfg, cfg), "Could not cast cfg into corev_cfg")
+
+    if (riscv_instr_pkg::RV32X inside {riscv_instr_pkg::supported_isa}) begin
+      instr = {instr,
+              $sformatf("csrr x%0d, 0x%0x", cfg.gpr[0], LPCOUNT1),
+              $sformatf("li x%0d, 2", cfg.gpr[1]),
+              $sformatf("bge x%0d, x%0d, 1f", cfg.gpr[0], cfg.gpr[1]),
+              $sformatf("2: csrr x%0d, 0x%0x", cfg.gpr[0], LPCOUNT0),
+              $sformatf("li x%0d, 2", cfg.gpr[1]),
+              $sformatf("bge x%0d, x%0d, 3f", cfg.gpr[0], cfg.gpr[1]),
+              $sformatf("beqz x0, 4f"),
+              $sformatf("1: csrr  x%0d, 0x%0x", cfg.gpr[0], MEPC),
+              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[1], LPEND1),
+              $sformatf("addi x%0d, x%0d, -4", cfg.gpr[1], cfg.gpr[1]),
+              $sformatf("bne x%0d, x%0d, 2b", cfg.gpr[0], cfg.gpr[1]),
+              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[0], LPSTART1),
+              $sformatf("beqz x0, 5f"),
+              $sformatf("3: csrr  x%0d, 0x%0x", cfg.gpr[0], MEPC),
+              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[1], LPEND0),
+              $sformatf("addi x%0d, x%0d, -4", cfg.gpr[1], cfg.gpr[1]),
+              $sformatf("bne x%0d, x%0d, 4f", cfg.gpr[0], cfg.gpr[1]),
+              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[0], LPSTART0),
+              $sformatf("beqz x0, 5f"),
+              $sformatf("4: csrr  x%0d, 0x%0x", cfg.gpr[0], MEPC),
+              $sformatf("addi  x%0d, x%0d, 4", cfg.gpr[0], cfg.gpr[0]),
+              $sformatf("5: csrw  0x%0x, x%0d", MEPC, cfg.gpr[0])
+      };
+    end else begin
+      instr = {instr,
+              $sformatf("csrr  x%0d, mepc", cfg.gpr[0]),
+              $sformatf("addi  x%0d, x%0d, 4", cfg.gpr[0], cfg.gpr[0]),
+              $sformatf("csrw  mepc, x%0d", cfg.gpr[0])
+      };
+    end
+    pop_regfile_from_kernel_stack(MSTATUS, MSCRATCH, cfg.mstatus_mprv, cfg.sp, cfg.tp, instr, corev_cfg);
+    instr.push_back("mret");
+    gen_section(get_label("ecall_handler", hart), instr);
+  endfunction : gen_ecall_handler
+
   // Override Ebreak trap handler - gen_ebreak_handler
   // Replace pop_gpr_from_kernel_stack with pop_regfile_from_kernel_stack
+  // With RV32X enabled, check for illegal instr on the last instr of hwloop
+  // If true, then set MEPC to first instr of hwloop instead of simply
+  // incrementing by 4.
   virtual function void gen_ebreak_handler(int hart);
     string instr[$];
     cv32e40p_instr_gen_config corev_cfg;
@@ -536,13 +584,39 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
 
     gen_signature_handshake(instr, CORE_STATUS, EBREAK_EXCEPTION);
     gen_signature_handshake(.instr(instr), .signature_type(WRITE_CSR), .csr(MCAUSE));
-    instr = {instr,
-            $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[0], MEPC),
-            $sformatf("addi  x%0d, x%0d, 4", cfg.gpr[0], cfg.gpr[0]),
-            $sformatf("csrw  0x%0x, x%0d", MEPC, cfg.gpr[0])
-    };
+    if (riscv_instr_pkg::RV32X inside {riscv_instr_pkg::supported_isa}) begin
+      instr = {instr,
+              $sformatf("csrr x%0d, 0x%0x", cfg.gpr[0], LPCOUNT1),
+              $sformatf("li x%0d, 2", cfg.gpr[1]),
+              $sformatf("bge x%0d, x%0d, 1f", cfg.gpr[0], cfg.gpr[1]),
+              $sformatf("2: csrr x%0d, 0x%0x", cfg.gpr[0], LPCOUNT0),
+              $sformatf("li x%0d, 2", cfg.gpr[1]),
+              $sformatf("bge x%0d, x%0d, 3f", cfg.gpr[0], cfg.gpr[1]),
+              $sformatf("beqz x0, 4f"),
+              $sformatf("1: csrr  x%0d, 0x%0x", cfg.gpr[0], MEPC),
+              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[1], LPEND1),
+              $sformatf("addi x%0d, x%0d, -4", cfg.gpr[1], cfg.gpr[1]),
+              $sformatf("bne x%0d, x%0d, 2b", cfg.gpr[0], cfg.gpr[1]),
+              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[0], LPSTART1),
+              $sformatf("beqz x0, 5f"),
+              $sformatf("3: csrr  x%0d, 0x%0x", cfg.gpr[0], MEPC),
+              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[1], LPEND0),
+              $sformatf("addi x%0d, x%0d, -4", cfg.gpr[1], cfg.gpr[1]),
+              $sformatf("bne x%0d, x%0d, 4f", cfg.gpr[0], cfg.gpr[1]),
+              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[0], LPSTART0),
+              $sformatf("beqz x0, 5f"),
+              $sformatf("4: csrr  x%0d, 0x%0x", cfg.gpr[0], MEPC),
+              $sformatf("addi  x%0d, x%0d, 4", cfg.gpr[0], cfg.gpr[0]),
+              $sformatf("5: csrw  0x%0x, x%0d", MEPC, cfg.gpr[0])
+      };
+    end else begin
+      instr = {instr,
+              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[0], MEPC),
+              $sformatf("addi  x%0d, x%0d, 4", cfg.gpr[0], cfg.gpr[0]),
+              $sformatf("csrw  0x%0x, x%0d", MEPC, cfg.gpr[0])
+      };
+    end
     // Replace pop_gpr_from_kernel_stack with pop_regfile_from_kernel_stack
-    //pop_gpr_from_kernel_stack(MSTATUS, MSCRATCH, cfg.mstatus_mprv, cfg.sp, cfg.tp, instr);
     pop_regfile_from_kernel_stack(MSTATUS, MSCRATCH, cfg.mstatus_mprv, cfg.sp, cfg.tp, instr, corev_cfg);
     instr.push_back("mret");
     gen_section(get_label("ebreak_handler", hart), instr);
@@ -594,7 +668,6 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
       };
     end
     // Replace pop_gpr_from_kernel_stack with pop_regfile_from_kernel_stack
-    //pop_gpr_from_kernel_stack(MSTATUS, MSCRATCH, cfg.mstatus_mprv, cfg.sp, cfg.tp, instr);
     pop_regfile_from_kernel_stack(MSTATUS, MSCRATCH, cfg.mstatus_mprv, cfg.sp, cfg.tp, instr, corev_cfg);
     instr.push_back("mret");
     gen_section(get_label("illegal_instr_handler", hart), instr);
@@ -616,7 +689,6 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
                                             instr);
     end
     // Replace pop_gpr_from_kernel_stack with pop_regfile_from_kernel_stack
-    //pop_gpr_from_kernel_stack(MSTATUS, MSCRATCH, cfg.mstatus_mprv, cfg.sp, cfg.tp, instr);
     pop_regfile_from_kernel_stack(MSTATUS, MSCRATCH, cfg.mstatus_mprv, cfg.sp, cfg.tp, instr, corev_cfg);
     instr.push_back("mret");
     gen_section(get_label("instr_fault_handler", hart), instr);
@@ -638,7 +710,6 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
                                             instr);
     end
     // Replace pop_gpr_from_kernel_stack with pop_regfile_from_kernel_stack
-    //pop_gpr_from_kernel_stack(MSTATUS, MSCRATCH, cfg.mstatus_mprv, cfg.sp, cfg.tp, instr);
     pop_regfile_from_kernel_stack(MSTATUS, MSCRATCH, cfg.mstatus_mprv, cfg.sp, cfg.tp, instr, corev_cfg);
     instr.push_back("mret");
     gen_section(get_label("load_fault_handler", hart), instr);
@@ -660,7 +731,6 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
                                             instr);
     end
     // Replace pop_gpr_from_kernel_stack with pop_regfile_from_kernel_stack
-    //pop_gpr_from_kernel_stack(MSTATUS, MSCRATCH, cfg.mstatus_mprv, cfg.sp, cfg.tp, instr);
     pop_regfile_from_kernel_stack(MSTATUS, MSCRATCH, cfg.mstatus_mprv, cfg.sp, cfg.tp, instr, corev_cfg);
     instr.push_back("mret");
     gen_section(get_label("store_fault_handler", hart), instr);

--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
@@ -154,10 +154,10 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
       num_loops_active inside {1,2,3};
 
       foreach(hwloop_counti[i])
-          hwloop_counti[i] inside {[0:100]};//TODO: check 0 is valid
+          hwloop_counti[i] inside {[0:64]};
 
       foreach(hwloop_count[i])
-          hwloop_count[i] inside {[0:100]};//TODO: check 0 is valid
+          hwloop_count[i] inside {[0:64]};
   }
 
   constraint num_hwloop_instr_c {
@@ -1226,10 +1226,10 @@ class cv32e40p_xpulp_long_hwloop_stream extends cv32e40p_xpulp_hwloop_base_strea
   constraint gen_hwloop_count_c {
       num_loops_active inside {1};
       foreach(hwloop_counti[i])
-          hwloop_counti[i] inside {[0:50]};//TODO: check 0 is valid
+          hwloop_counti[i] inside {[0:25]};
 
       foreach(hwloop_count[i])
-          hwloop_count[i] inside {[0:50]};//TODO: check 0 is valid
+          hwloop_count[i] inside {[0:25]};
   }
 
 

--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
@@ -216,10 +216,10 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
           } else {
             if (use_setup_inst[1] && use_loop_setupi_inst[1]) { //with setupi only [4:0] uimmS range avail for end label
                 if(use_setup_inst[0]) {
-                  num_hwloop_instr[0] inside {[3:27]}; //TODO:in nested hwloop0 with setupi instr more than 27 instructions will have issue if setupi used for hwloop1?
+                  num_hwloop_instr[0] inside {[3:27]}; //For nested hwloop0 with setupi instr more than 27 instructions will have issue if setupi used for hwloop1
                   num_hwloop_instr[1] >= num_hwloop_instr[0] + 1 + 2; // num_hwloop_ctrl_instr[0] == 1 ; 2 for end of loop req
                 } else {
-                  num_hwloop_instr[0] inside {[3:25]}; //TODO:in nested hwloop0 with setupi instr more than 27 instructions will have issue if setupi used for hwloop1?
+                  num_hwloop_instr[0] inside {[3:25]}; //For nested hwloop0 with setupi instr more than 27 instructions will have issue if setupi used for hwloop1
                   num_hwloop_instr[1] >= num_hwloop_instr[0] + 3 + 2; // num_hwloop_ctrl_instr[0] == 3 ; 2 for end of loop req
                 }
                 //num_hwloop_instr[1] inside {[6:30]};
@@ -428,7 +428,7 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
               insert_rand_instr(.num_rand_instr(num_fill_instr_loop_ctrl_to_loop_start[1]),
                                 .no_branch(1),
                                 .no_compressed(0),
-                                .no_fence(0));  //TODO: Fence instr allowed here?
+                                .no_fence(0));  //Fence instr allowed here
           end
           else begin
               set_label_at_next_instr = 1; //no rand instr so next instruction must have a label
@@ -498,7 +498,7 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
                                        .label_is_pulp_hwloop_body_label(1),
                                        .no_branch(1),
                                        .no_compressed(0),
-                                       .no_fence(0)); //TODO: Fence instr allowed here?
+                                       .no_fence(0)); //Fence instr allowed here
 
           insert_rand_instr(.num_rand_instr($urandom_range(0,20)),
                             .no_branch(1),
@@ -561,7 +561,7 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
 
               //Insert Random instructions till Loop HWLOOP_START0/1 label ->  use_setup_inst ? 0 : num_fill_instr_loop_ctrl_to_loop_start[0/1]
               if(!use_setup_inst[hwloop_L])
-                  insert_rand_instr((num_fill_instr_loop_ctrl_to_loop_start[hwloop_L]),1,0,0);  // allow compressed instructions here ; TODO: Fence instr allowed here?
+                  insert_rand_instr((num_fill_instr_loop_ctrl_to_loop_start[hwloop_L]),1,0,0);  // allow compressed instructions here ; Fence instr allowed here
 
               //LABEL HWLOOP_START0/1:
               insert_rand_instr_with_label(start_label_s,1); // no branch, no compressed, no fence instructions inside hwloop
@@ -575,7 +575,7 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
                                            .label_is_pulp_hwloop_body_label(1),
                                            .no_branch(1),
                                            .no_compressed(0),
-                                           .no_fence(0)); //TODO: Fence instr allowed here?
+                                           .no_fence(0)); //Fence instr allowed here
 
               //<Some more Random instructions>
               // allow compressed, fence instructions here
@@ -1102,12 +1102,12 @@ class cv32e40p_xpulp_short_hwloop_stream extends cv32e40p_xpulp_hwloop_base_stre
       } else {
         foreach(hwloop_counti[i])
           hwloop_counti[i] dist {[0:400] := 10, [401:1023] := 300, [1024:2047] := 150,
-                                 [2048:4095] := 50, 4095 := 300}; //TODO: check 0 is valid
+                                 [2048:4095] := 50, 4095 := 300};
 
         //TODO: for rs1 32 bit count ?
         foreach(hwloop_count[i])
           hwloop_count[i] dist {[0:400] := 10, [401:1023] := 300, [1024:2047] := 150,
-                                [2048:4094] := 50, 4095 := 300};//TODO: check 0 is valid
+                                [2048:4094] := 50, 4095 := 300};
       }
   }
 

--- a/cv32e40p/regress/cv32e40pv2_interrupt_debug.yaml
+++ b/cv32e40p/regress/cv32e40pv2_interrupt_debug.yaml
@@ -204,6 +204,7 @@ tests:
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
     test_cfg: debug_single_step_en
+    num: 1
 
   corev_rand_pulp_hwloop_debug_trigger:
     testname: corev_rand_pulp_hwloop_debug
@@ -228,6 +229,7 @@ tests:
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
     test_cfg: debug_trigger_basic,debug_single_step_en
+    num: 1
 
   corev_rand_pulp_hwloop_debug_with_interrupt:
     testname: corev_rand_pulp_hwloop_debug
@@ -252,6 +254,7 @@ tests:
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
     test_cfg: gen_rand_int,debug_trigger_basic,debug_single_step_en
+    num: 1
 
   corev_rand_pulp_hwloop_interrupt_test:
     testname: corev_rand_pulp_hwloop_test
@@ -268,6 +271,7 @@ tests:
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
     test_cfg: debug_single_step_en
+    num: 1
 
   corev_rand_pulp_hwloop_exception_debug_trigger:
     testname: corev_rand_pulp_hwloop_exception

--- a/cv32e40p/regress/cv32e40pv2_interrupt_debug.yaml
+++ b/cv32e40p/regress/cv32e40pv2_interrupt_debug.yaml
@@ -68,12 +68,14 @@ tests:
     description: corev_rand_interrupt_debug
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_debug CFG_PLUSARGS="+UVM_TIMEOUT=2000000"
+    num: 1
 
   corev_rand_interrupt_exception:
     build: uvmt_cv32e40p
     description: corev_rand_interrupt_exception
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_exception CFG_PLUSARGS="+UVM_TIMEOUT=2000000"
+    num: 1
 
   corev_rand_interrupt_nested:
     build: uvmt_cv32e40p
@@ -87,6 +89,7 @@ tests:
     description: corev_rand_interrupt_wfi
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi CFG_PLUSARGS="+UVM_TIMEOUT=2000000"
+    num: 1
 
   corev_rand_interrupt_wfi_mem_stress:
     build: uvmt_cv32e40p

--- a/cv32e40p/regress/cv32e40pv2_interrupt_debug_long.yaml
+++ b/cv32e40p/regress/cv32e40pv2_interrupt_debug_long.yaml
@@ -74,3 +74,36 @@ tests:
     description: corev_rand_interrupt_wfi_mem_stress
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+
+  corev_rand_pulp_hwloop_debug_single_step:
+    testname: corev_rand_pulp_hwloop_debug
+    description: hwloop single-step debug random test
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
+    test_cfg: debug_single_step_en
+
+  corev_rand_pulp_hwloop_debug_trigger_with_single_step:
+    testname: corev_rand_pulp_hwloop_debug
+    description: hwloop debug random test with debug trigger and single step
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
+    test_cfg: debug_trigger_basic,debug_single_step_en
+
+  corev_rand_pulp_hwloop_debug_with_int_debug_trigger_single_step:
+    testname: corev_rand_pulp_hwloop_debug
+    description: hwloop debug with interrupt, debug trigger and single step random test
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
+    test_cfg: gen_rand_int,debug_trigger_basic,debug_single_step_en
+
+  corev_rand_pulp_hwloop_exception_single_step_debug:
+    testname: corev_rand_pulp_hwloop_exception
+    description: hwloop exception test with single step debug
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
+    test_cfg: debug_single_step_en
+

--- a/cv32e40p/regress/cv32e40pv2_interrupt_debug_long.yaml
+++ b/cv32e40p/regress/cv32e40pv2_interrupt_debug_long.yaml
@@ -51,23 +51,35 @@ tests:
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_single_step_xpulp CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
 
+  corev_rand_interrupt:
+    build: uvmt_cv32e40p
+    description: corev_rand_interrupt
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+
+  corev_rand_interrupt_debug:
+    build: uvmt_cv32e40p
+    description: corev_rand_interrupt_debug
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+
+  corev_rand_interrupt_exception:
+    build: uvmt_cv32e40p
+    description: corev_rand_interrupt_exception
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_exception CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+
   corev_rand_interrupt_nested:
     build: uvmt_cv32e40p
     description: corev_rand_interrupt_nested
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_nested CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
 
-  corev_rand_interrupt_wfi_mem_stress:
+  corev_rand_interrupt_wfi:
     build: uvmt_cv32e40p
-    description: corev_rand_interrupt_wfi_mem_stress
+    description: corev_rand_interrupt_wfi
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress CFG_PLUSARGS="+UVM_TIMEOUT=2000000"
-
-  corev_rand_interrupt:
-    build: uvmt_cv32e40p
-    description: corev_rand_interrupt
-    dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
 
   corev_rand_interrupt_wfi_mem_stress:
     build: uvmt_cv32e40p

--- a/cv32e40p/regress/cv32e40pv2_interrupt_debug_short.yaml
+++ b/cv32e40p/regress/cv32e40pv2_interrupt_debug_short.yaml
@@ -21,24 +21,6 @@ builds:
 
 # List of tests
 tests:
-  corev_rand_interrupt_debug:
-    build: uvmt_cv32e40p
-    description: corev_rand_interrupt_debug
-    dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_debug CFG_PLUSARGS="+UVM_TIMEOUT=8000000"
-
-  corev_rand_interrupt_exception:
-    build: uvmt_cv32e40p
-    description: corev_rand_interrupt_exception
-    dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_exception CFG_PLUSARGS="+UVM_TIMEOUT=8000000"
-
-  corev_rand_interrupt_wfi:
-    build: uvmt_cv32e40p
-    description: corev_rand_interrupt_wfi
-    dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi CFG_PLUSARGS="+UVM_TIMEOUT=8000000"
-
   corev_rand_pulp_instr_ebreak_debug_test:
     testname: corev_rand_pulp_instr_test
     description: pulp rand test with ebreak debug
@@ -85,14 +67,6 @@ tests:
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
     test_cfg: debug_ebreak
 
-  corev_rand_pulp_hwloop_debug_single_step:
-    testname: corev_rand_pulp_hwloop_debug
-    description: hwloop single-step debug random test
-    build: uvmt_cv32e40p
-    dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
-    test_cfg: debug_single_step_en
-
   corev_rand_pulp_hwloop_debug_trigger:
     testname: corev_rand_pulp_hwloop_debug
     description: hwloop debug random test with debug trigger on instr addr match
@@ -108,14 +82,6 @@ tests:
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
     test_cfg: debug_trigger_basic,debug_ebreak
-
-  corev_rand_pulp_hwloop_debug_trigger_with_single_step:
-    testname: corev_rand_pulp_hwloop_debug
-    description: hwloop debug random test with debug trigger and single step
-    build: uvmt_cv32e40p
-    dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
-    test_cfg: debug_trigger_basic,debug_single_step_en
 
   corev_rand_pulp_hwloop_debug_with_interrupt:
     testname: corev_rand_pulp_hwloop_debug
@@ -133,14 +99,6 @@ tests:
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
     test_cfg: gen_rand_int,debug_trigger_basic
 
-  corev_rand_pulp_hwloop_debug_with_int_debug_trigger_single_step:
-    testname: corev_rand_pulp_hwloop_debug
-    description: hwloop debug with interrupt, debug trigger and single step random test
-    build: uvmt_cv32e40p
-    dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
-    test_cfg: gen_rand_int,debug_trigger_basic,debug_single_step_en
-
   corev_rand_pulp_hwloop_interrupt_test:
     testname: corev_rand_pulp_hwloop_test
     description: hwloop test with random interrupts
@@ -148,14 +106,6 @@ tests:
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_test CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
     test_cfg: gen_rand_int
-
-  corev_rand_pulp_hwloop_exception_single_step_debug:
-    testname: corev_rand_pulp_hwloop_exception
-    description: hwloop exception test with single step debug
-    build: uvmt_cv32e40p
-    dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
-    test_cfg: debug_single_step_en
 
   corev_rand_pulp_hwloop_exception_debug_trigger:
     testname: corev_rand_pulp_hwloop_exception

--- a/cv32e40p/regress/cv32e40pv2_xpulp_instr.yaml
+++ b/cv32e40p/regress/cv32e40pv2_xpulp_instr.yaml
@@ -52,7 +52,7 @@ tests:
     build: uvmt_cv32e40p
     description: hwloop exception test
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=4000000"
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
 
   corev_rand_pulp_illegal_instr_test:
     testname: corev_rand_pulp_instr_test

--- a/cv32e40p/sim/ExternalRepos.mk
+++ b/cv32e40p/sim/ExternalRepos.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40p
 CV_CORE_BRANCH ?= dev
-CV_CORE_HASH   ?= 3023e88a8ce07c6854267031637403ea6a8061bb
+CV_CORE_HASH   ?= 6deff44db36b7656bb1aa651b47d8145cd288b44
 CV_CORE_TAG    ?= none
 
 # The CV_CORE_HASH above points to version of the RTL that is newer.

--- a/cv32e40p/tests/programs/corev-dv/corev_rand_pulp_hwloop_debug/corev-dv.yaml
+++ b/cv32e40p/tests/programs/corev-dv/corev_rand_pulp_hwloop_debug/corev-dv.yaml
@@ -15,7 +15,7 @@ plusargs: >
     +rand_directed_instr_0=cv32e40p_xpulp_hwloop_base_stream,1
     +rand_directed_instr_1=cv32e40p_xpulp_hwloop_base_stream,1
     +rand_directed_instr_2=cv32e40p_xpulp_short_hwloop_stream,1
-    +rand_directed_instr_3=cv32e40p_xpulp_long_hwloop_stream,1
+    +rand_directed_instr_3=cv32e40p_xpulp_short_hwloop_stream,1
     +rand_directed_instr_4=cv32e40p_xpulp_hwloop_isa_stress_stream,1
     +rand_directed_instr_5=cv32e40p_xpulp_hwloop_exception,1
     +no_fence=1


### PR DESCRIPTION
Fixes in this PR:  

1. Move some long running hwloop tests to long list
2. Reduce hwloop count for hwloop random streams to optimize simulation run time
3. Add override for ecall_handler, similar to other handlers
4. Update ebreak handler to handle hwloops