### PR TITLE
cv32e40p corev_dv fixes for illegal handler and debug program

### DIFF
--- a/cv32e40p/env/corev-dv/cv32e40p_debug_rom_gen.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_debug_rom_gen.sv
@@ -115,7 +115,7 @@ class cv32e40p_debug_rom_gen extends riscv_debug_rom_gen;
             format_section(debug_main);
             gen_sub_program(hart, sub_program[hart], sub_program_name,
                             cfg.num_debug_sub_program, 1'b1, "debug_sub");
-            main_program[hart] = riscv_instr_sequence::type_id::create("debug_program");
+            main_program[hart] = cv32e40p_instr_sequence::type_id::create("debug_program");
             main_program[hart].instr_cnt = cfg.debug_program_instr_cnt;            
             main_program[hart].is_debug_program = 1;
             main_program[hart].cfg = cfg;

--- a/cv32e40p/env/corev-dv/cv32e40p_instr_sequence.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_instr_sequence.sv
@@ -175,6 +175,12 @@ class cv32e40p_instr_sequence extends riscv_instr_sequence;
           instr_stream.instr_list[i].has_label = 1'b0;
         end
       end
+      // Remove all pulp store instructions inside debug_program
+      if(is_debug_program == 1) begin
+        if (instr_stream.instr_list[i].instr_name inside {CV_SB, CV_SH, CV_SW} ) begin
+            instr_stream.instr_list.delete(i);
+        end
+      end
       i++;
     end // while
     `uvm_info(get_full_name(), "Finished post-processing instructions", UVM_HIGH)

--- a/cv32e40p/regress/cv32e40pv2_interrupt_debug_long.yaml
+++ b/cv32e40p/regress/cv32e40pv2_interrupt_debug_long.yaml
@@ -92,7 +92,7 @@ tests:
     description: hwloop single-step debug random test
     build: uvmt_cv32e40p
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
     test_cfg: debug_single_step_en
 
   corev_rand_pulp_hwloop_debug_trigger_with_single_step:
@@ -100,7 +100,7 @@ tests:
     description: hwloop debug random test with debug trigger and single step
     build: uvmt_cv32e40p
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
     test_cfg: debug_trigger_basic,debug_single_step_en
 
   corev_rand_pulp_hwloop_debug_with_int_debug_trigger_single_step:
@@ -108,7 +108,7 @@ tests:
     description: hwloop debug with interrupt, debug trigger and single step random test
     build: uvmt_cv32e40p
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
     test_cfg: gen_rand_int,debug_trigger_basic,debug_single_step_en
 
   corev_rand_pulp_hwloop_exception_single_step_debug:
@@ -116,6 +116,6 @@ tests:
     description: hwloop exception test with single step debug
     build: uvmt_cv32e40p
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
     test_cfg: debug_single_step_en
 

--- a/cv32e40p/regress/cv32e40pv2_interrupt_debug_short.yaml
+++ b/cv32e40p/regress/cv32e40pv2_interrupt_debug_short.yaml
@@ -57,14 +57,14 @@ tests:
     build: uvmt_cv32e40p
     description: hwloop debug random test
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=25000000"
 
   corev_rand_pulp_hwloop_debug_ebreak:
     testname: corev_rand_pulp_hwloop_debug
     description: hwloop ebreak debug random test
     build: uvmt_cv32e40p
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=25000000"
     test_cfg: debug_ebreak
 
   corev_rand_pulp_hwloop_debug_trigger:
@@ -72,7 +72,7 @@ tests:
     description: hwloop debug random test with debug trigger on instr addr match
     build: uvmt_cv32e40p
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=25000000"
     test_cfg: debug_trigger_basic
 
   corev_rand_pulp_hwloop_debug_trigger_with_ebreak:
@@ -80,7 +80,7 @@ tests:
     description: hwloop debug random test with debug trigger and ebreak
     build: uvmt_cv32e40p
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=25000000"
     test_cfg: debug_trigger_basic,debug_ebreak
 
   corev_rand_pulp_hwloop_debug_with_interrupt:
@@ -88,7 +88,7 @@ tests:
     description: hwloop debug with interrupt random test
     build: uvmt_cv32e40p
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=25000000"
     test_cfg: gen_rand_int
 
   corev_rand_pulp_hwloop_debug_with_int_debug_trigger:
@@ -96,7 +96,7 @@ tests:
     description: hwloop debug with interrupt and debug trigger random test
     build: uvmt_cv32e40p
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=25000000"
     test_cfg: gen_rand_int,debug_trigger_basic
 
   corev_rand_pulp_hwloop_interrupt_test:
@@ -104,7 +104,7 @@ tests:
     description: hwloop test with random interrupts
     build: uvmt_cv32e40p
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_test CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_test CFG_PLUSARGS="+UVM_TIMEOUT=25000000"
     test_cfg: gen_rand_int
 
   corev_rand_pulp_hwloop_exception_debug_trigger:

--- a/cv32e40p/regress/cv32e40pv2_xpulp_instr.yaml
+++ b/cv32e40p/regress/cv32e40pv2_xpulp_instr.yaml
@@ -28,7 +28,7 @@ tests:
     build: uvmt_cv32e40p
     description: corev_rand_pulp_hwloop_test
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_hwloop_test CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_hwloop_test CFG_PLUSARGS="+UVM_TIMEOUT=20000000"
 
   corev_rand_pulp_instr_test:
     build: uvmt_cv32e40p
@@ -52,7 +52,7 @@ tests:
     build: uvmt_cv32e40p
     description: hwloop exception test
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=15000000"
 
   corev_rand_pulp_illegal_instr_test:
     testname: corev_rand_pulp_instr_test
@@ -67,7 +67,7 @@ tests:
     description: hwloop test with illegal instructions
     build: uvmt_cv32e40p
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_test CFG_PLUSARGS="+UVM_TIMEOUT=40000000"
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_test CFG_PLUSARGS="+UVM_TIMEOUT=25000000"
     test_cfg: insert_illegal_instr
 
   pulp_hardware_loop:


### PR DESCRIPTION
PR has fixes for :

1. Illegal_handler update to decrement lpcount csr value for case of illegal on last hwloop body instr
2. fix issue in debug program to remove pulp store instructions from random stream
3. reduce uvm timeouts for regress lists