### PR TITLE
PR for fixes from regression

### DIFF
--- a/cv32e40p/env/corev-dv/cv32e40p_asm_program_gen.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_asm_program_gen.sv
@@ -526,8 +526,9 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
   // Override ECALL trap handler - gen_ecall_handler of corev-dv
   // Replace pop_gpr_from_kernel_stack with pop_regfile_from_kernel_stack
   // With RV32X enabled, check for ecall instr on the last instr of hwloop
-  // If true, then set MEPC to first instr of hwloop instead of simply
-  // incrementing by 4.
+  // If true, then
+  // (a) Set MEPC to first instr of hwloop body
+  // (b) Add logic to decrement the LPCOUNT
   virtual function void gen_ecall_handler(int hart);
     string instr[$];
     cv32e40p_instr_gen_config corev_cfg;
@@ -536,28 +537,7 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
 
     if (riscv_instr_pkg::RV32X inside {riscv_instr_pkg::supported_isa}) begin
       instr = {instr,
-              $sformatf("csrr x%0d, 0x%0x", cfg.gpr[0], LPCOUNT1),
-              $sformatf("li x%0d, 2", cfg.gpr[1]),
-              $sformatf("bge x%0d, x%0d, 1f", cfg.gpr[0], cfg.gpr[1]),
-              $sformatf("2: csrr x%0d, 0x%0x", cfg.gpr[0], LPCOUNT0),
-              $sformatf("li x%0d, 2", cfg.gpr[1]),
-              $sformatf("bge x%0d, x%0d, 3f", cfg.gpr[0], cfg.gpr[1]),
-              $sformatf("beqz x0, 4f"),
-              $sformatf("1: csrr  x%0d, 0x%0x", cfg.gpr[0], MEPC),
-              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[1], LPEND1),
-              $sformatf("addi x%0d, x%0d, -4", cfg.gpr[1], cfg.gpr[1]),
-              $sformatf("bne x%0d, x%0d, 2b", cfg.gpr[0], cfg.gpr[1]),
-              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[0], LPSTART1),
-              $sformatf("beqz x0, 5f"),
-              $sformatf("3: csrr  x%0d, 0x%0x", cfg.gpr[0], MEPC),
-              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[1], LPEND0),
-              $sformatf("addi x%0d, x%0d, -4", cfg.gpr[1], cfg.gpr[1]),
-              $sformatf("bne x%0d, x%0d, 4f", cfg.gpr[0], cfg.gpr[1]),
-              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[0], LPSTART0),
-              $sformatf("beqz x0, 5f"),
-              $sformatf("4: csrr  x%0d, 0x%0x", cfg.gpr[0], MEPC),
-              $sformatf("addi  x%0d, x%0d, 4", cfg.gpr[0], cfg.gpr[0]),
-              $sformatf("5: csrw  0x%0x, x%0d", MEPC, cfg.gpr[0])
+               `COMMON_HWLOOP_EXC_HANDLING_CODE
       };
     end else begin
       instr = {instr,
@@ -574,8 +554,9 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
   // Override Ebreak trap handler - gen_ebreak_handler
   // Replace pop_gpr_from_kernel_stack with pop_regfile_from_kernel_stack
   // With RV32X enabled, check for ebreak instr on the last instr of hwloop
-  // If true, then set MEPC to first instr of hwloop instead of simply
-  // incrementing by 4.
+  // If true, then
+  // (a) Set MEPC to first instr of hwloop body
+  // (b) Add logic to decrement the LPCOUNT
   virtual function void gen_ebreak_handler(int hart);
     string instr[$];
     cv32e40p_instr_gen_config corev_cfg;
@@ -586,28 +567,7 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
     gen_signature_handshake(.instr(instr), .signature_type(WRITE_CSR), .csr(MCAUSE));
     if (riscv_instr_pkg::RV32X inside {riscv_instr_pkg::supported_isa}) begin
       instr = {instr,
-              $sformatf("csrr x%0d, 0x%0x", cfg.gpr[0], LPCOUNT1),
-              $sformatf("li x%0d, 2", cfg.gpr[1]),
-              $sformatf("bge x%0d, x%0d, 1f", cfg.gpr[0], cfg.gpr[1]),
-              $sformatf("2: csrr x%0d, 0x%0x", cfg.gpr[0], LPCOUNT0),
-              $sformatf("li x%0d, 2", cfg.gpr[1]),
-              $sformatf("bge x%0d, x%0d, 3f", cfg.gpr[0], cfg.gpr[1]),
-              $sformatf("beqz x0, 4f"),
-              $sformatf("1: csrr  x%0d, 0x%0x", cfg.gpr[0], MEPC),
-              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[1], LPEND1),
-              $sformatf("addi x%0d, x%0d, -4", cfg.gpr[1], cfg.gpr[1]),
-              $sformatf("bne x%0d, x%0d, 2b", cfg.gpr[0], cfg.gpr[1]),
-              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[0], LPSTART1),
-              $sformatf("beqz x0, 5f"),
-              $sformatf("3: csrr  x%0d, 0x%0x", cfg.gpr[0], MEPC),
-              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[1], LPEND0),
-              $sformatf("addi x%0d, x%0d, -4", cfg.gpr[1], cfg.gpr[1]),
-              $sformatf("bne x%0d, x%0d, 4f", cfg.gpr[0], cfg.gpr[1]),
-              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[0], LPSTART0),
-              $sformatf("beqz x0, 5f"),
-              $sformatf("4: csrr  x%0d, 0x%0x", cfg.gpr[0], MEPC),
-              $sformatf("addi  x%0d, x%0d, 4", cfg.gpr[0], cfg.gpr[0]),
-              $sformatf("5: csrw  0x%0x, x%0d", MEPC, cfg.gpr[0])
+               `COMMON_HWLOOP_EXC_HANDLING_CODE
       };
     end else begin
       instr = {instr,
@@ -638,63 +598,7 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
     gen_signature_handshake(.instr(instr), .signature_type(WRITE_CSR), .csr(MCAUSE));
     if (riscv_instr_pkg::RV32X inside {riscv_instr_pkg::supported_isa}) begin
       instr = {instr,
-              // Check LPCOUNT1 >= 1
-              $sformatf("csrr x%0d, 0x%0x", cfg.gpr[0], LPCOUNT1),
-              $sformatf("li x%0d, 1", cfg.gpr[1]),
-              $sformatf("bge x%0d, x%0d, 1f", cfg.gpr[0], cfg.gpr[1]),
-              // Check LPCOUNT0 >= 1
-              $sformatf("2: csrr x%0d, 0x%0x", cfg.gpr[0], LPCOUNT0),
-              $sformatf("li x%0d, 1", cfg.gpr[1]),
-              $sformatf("bge x%0d, x%0d, 3f", cfg.gpr[0], cfg.gpr[1]),
-              // Since both LPCOUNT0 & LPCOUNT1 equals 0
-              // Nothing needs to be done for HWLOOPs and its CSRs
-              $sformatf("beqz x0, 4f"),
-
-              // HWLOOP1 Handling
-              // Check for ILLEGAL being the LAST HWLOOP Body instr
-              $sformatf("1: csrr  x%0d, 0x%0x", cfg.gpr[0], MEPC),
-              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[1], LPEND1),
-              $sformatf("addi x%0d, x%0d, -4", cfg.gpr[1], cfg.gpr[1]),
-              $sformatf("bne x%0d, x%0d, 2b", cfg.gpr[0], cfg.gpr[1]),
-              // Else, If equal this means the illegal instr was the last
-              // hwloop body instr, thus we handle the HWLOOP manually here
-              // First decrement lpcount CSR manually as CSR not updated in HW
-              $sformatf("csrr x%0d, 0x%0x", cfg.gpr[1], LPCOUNT1),
-              $sformatf("addi x%0d, x%0d, -1", cfg.gpr[1], cfg.gpr[1]),
-              $sformatf("cv.count 1, x%0d", cfg.gpr[1]),
-              // Check if the current LPCOUNT1 value == 0, if so, then MEPC=MEPC+4
-              $sformatf("csrr x%0d, 0x%0x", cfg.gpr[1], LPCOUNT1),
-              $sformatf("beqz x%0d, 4f", cfg.gpr[1]),
-              // Else LPCOUNT1 still >=1 and thus next,
-              // Set the next MEPC to LPSTART1 for next HWLOOP iteration
-              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[0], LPSTART1),
-              $sformatf("beqz x0, 5f"),
-
-              // HWLOOP0 Handling
-              // Check for ILLEGAL being the LAST HWLOOP Body instr
-              $sformatf("3: csrr  x%0d, 0x%0x", cfg.gpr[0], MEPC),
-              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[1], LPEND0),
-              $sformatf("addi x%0d, x%0d, -4", cfg.gpr[1], cfg.gpr[1]),
-              $sformatf("bne x%0d, x%0d, 4f", cfg.gpr[0], cfg.gpr[1]),
-              // Else, If equal this means the illegal instr was the last
-              // hwloop body instr, thus we handle the HWLOOP manually here
-              // First decrement lpcount CSR manually as CSR not updated in HW
-              $sformatf("csrr x%0d, 0x%0x", cfg.gpr[1], LPCOUNT0),
-              $sformatf("addi x%0d, x%0d, -1", cfg.gpr[1], cfg.gpr[1]),
-              $sformatf("cv.count 0, x%0d", cfg.gpr[1]),
-              // Check if the current LPCOUNT0 value == 0, if so, then MEPC=MEPC+4
-              $sformatf("csrr x%0d, 0x%0x", cfg.gpr[1], LPCOUNT0),
-              $sformatf("beqz x%0d, 4f", cfg.gpr[1]),
-              // Else LPCOUNT0 still >=1 and thus next,
-              // Set the next MEPC to LPSTART0 for next HWLOOP iteration
-              $sformatf("csrr  x%0d, 0x%0x", cfg.gpr[0], LPSTART0),
-              $sformatf("beqz x0, 5f"),
-
-              // Default increment for MEPC by 4
-              $sformatf("4: csrr  x%0d, 0x%0x", cfg.gpr[0], MEPC),
-              $sformatf("addi  x%0d, x%0d, 4", cfg.gpr[0], cfg.gpr[0]),
-              // Write MEPC
-              $sformatf("5: csrw  0x%0x, x%0d", MEPC, cfg.gpr[0])
+               `COMMON_HWLOOP_EXC_HANDLING_CODE
       };
     end else begin
       instr = {instr,

--- a/cv32e40p/env/corev-dv/cv32e40p_illegal_instr.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_illegal_instr.sv
@@ -43,6 +43,10 @@ class cv32e40p_illegal_instr extends riscv_illegal_instr;
 
   function void cv32e40p_init(riscv_instr_gen_config cfg);
     this.cfg = cfg;
+    if (riscv_instr_pkg::RV32FC inside {riscv_instr_pkg::supported_isa}) begin
+      legal_c00_opcode = {legal_c00_opcode, 3'b011, 3'b111};
+      legal_c10_opcode = {legal_c10_opcode, 3'b011, 3'b111};
+    end
     if (riscv_instr_pkg::RV32ZFINX inside {riscv_instr_pkg::supported_isa}) begin
       legal_opcode = {legal_opcode, 7'b1000011, 7'b1000111, 7'b1001011,
                                     7'b1001111, 7'b1010011};

--- a/cv32e40p/sim/ExternalRepos.mk
+++ b/cv32e40p/sim/ExternalRepos.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40p
 CV_CORE_BRANCH ?= dev
-CV_CORE_HASH   ?= 6deff44db36b7656bb1aa651b47d8145cd288b44
+CV_CORE_HASH   ?= 04bbad22069fddb9c07255419d04a7d0f409684e
 CV_CORE_TAG    ?= none
 
 # The CV_CORE_HASH above points to version of the RTL that is newer.

--- a/cv32e40p/tb/uvmt/imperas_dv.flist
+++ b/cv32e40p/tb/uvmt/imperas_dv.flist
@@ -25,7 +25,7 @@
 +incdir+${IMPERAS_HOME}/ImpProprietary/include/host
 +incdir+${IMPERAS_HOME}/ImpProprietary/source/host/CV32E40Pv2_riscvISACOV/source
 
-${TBSRC_HOME}/uvmt/uvmt_cv32e40p_imperas_riscv_coverage_config.svh
+//${TBSRC_HOME}/uvmt/uvmt_cv32e40p_imperas_riscv_coverage_config.svh
 -f ${IMPERAS_HOME}/ImpPublic/source/host/rvvi/rvvi.f
 -f ${IMPERAS_HOME}/ImpProprietary/source/host/idv/idv.f
 


### PR DESCRIPTION
Following fixes added:

1. zfinx config register randomization update in hwloop stream to randomization fatal errors
2. Update exception handlers in corev-dv with hwloop handling logic for all 3 exception handlers
3. Update compressed legal opcode list for r32fc for correct illegal stream generation
4. temporarily comment out Imperas isacov coverage
5. Update core hash 