### PR TITLE
Controls to disable all logging for cv32e40p simulations

### DIFF
--- a/cv32e40p/tests/test_cfg/disable_all_trn_logs.yaml
+++ b/cv32e40p/tests/test_cfg/disable_all_trn_logs.yaml
@@ -1,0 +1,5 @@
+name: disable_all_trn_logs
+description: >
+    Disable All Transaction Logs
+plusargs: >
+    +disable_all_trn_logs

--- a/cv32e40p/tests/uvmt/compliance-tests/uvmt_cv32e40p_firmware_test.sv
+++ b/cv32e40p/tests/uvmt/compliance-tests/uvmt_cv32e40p_firmware_test.sv
@@ -35,10 +35,22 @@
  */
 class uvmt_cv32e40p_firmware_test_c extends uvmt_cv32e40p_base_test_c;
 
+   bit disable_all_trn_logs;
+
    constraint env_cfg_cons {
       env_cfg.enabled         == 1;
       env_cfg.is_active       == UVM_ACTIVE;
-      env_cfg.trn_log_enabled == 1;
+      if (disable_all_trn_logs) {
+       env_cfg.trn_log_enabled                       == 0;
+       env_cfg.clknrst_cfg.trn_log_enabled           == 0;
+       env_cfg.interrupt_cfg.trn_log_enabled         == 0;
+       env_cfg.debug_cfg.trn_log_enabled             == 0;
+       env_cfg.obi_memory_instr_cfg.trn_log_enabled  == 0;
+       env_cfg.obi_memory_data_cfg.trn_log_enabled   == 0;
+       env_cfg.rvfi_cfg.trn_log_enabled              == 0;
+      } else {
+       env_cfg.trn_log_enabled == 1;
+      }
    }
    `uvm_component_utils_begin(uvmt_cv32e40p_firmware_test_c)
    `uvm_object_utils_end
@@ -86,7 +98,11 @@ function uvmt_cv32e40p_firmware_test_c::new(string name="uvmt_cv32e40p_firmware_
 
    super.new(name, parent);
    if ($test$plusargs("gen_reduced_rand_dbg_req")) begin
-        uvme_cv32e40p_random_debug_c::type_id::set_type_override(uvme_cv32e40p_reduced_rand_debug_req_c::get_type());
+    uvme_cv32e40p_random_debug_c::type_id::set_type_override(uvme_cv32e40p_reduced_rand_debug_req_c::get_type());
+   end
+   disable_all_trn_logs = 0;
+   if ($test$plusargs("disable_all_trn_logs")) begin
+    disable_all_trn_logs = 1;
    end
    `uvm_info("TEST", "This is the FIRMWARE TEST", UVM_NONE)
 

--- a/mk/uvmt/uvmt.mk
+++ b/mk/uvmt/uvmt.mk
@@ -93,6 +93,9 @@ GEN_START_INDEX ?= 0
 GEN_NUM_TESTS   ?= 1
 export RUN_INDEX       ?= 0
 
+# Generate Core Trace logs
+ENABLE_TRACE_LOG  ?= YES
+
 # Common test runtime plusargs from external file, used as test-configuration
 # Test Name with test-configuration
 TEST_RUN_NAME =  $(if $(TEST_CFG_FILE_NAME),$(TEST)_$(TEST_CFG_FILE_NAME),$(TEST))

--- a/mk/uvmt/vcs.mk
+++ b/mk/uvmt/vcs.mk
@@ -155,7 +155,12 @@ endif
 ################################################################################
 
 VCS_FILE_LIST ?= -f $(DV_UVMT_PATH)/uvmt_$(CV_CORE_LC).flist
-VCS_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_TRACE_EXECUTION
+
+ifeq ($(call IS_YES,$(ENABLE_TRACE_LOG)),YES)
+    VCS_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_TRACE_EXECUTION
+    VCS_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_RVFI_TRACE_EXECUTION
+endif
+
 ifeq ($(call IS_YES,$(USE_ISS)),YES)
     VCS_USER_COMPILE_ARGS += +define+USE_ISS
     VCS_USER_COMPILE_ARGS += +define+USE_IMPERASDV

--- a/mk/uvmt/vsim.mk
+++ b/mk/uvmt/vsim.mk
@@ -133,9 +133,13 @@ VLOG_FILE_LIST = -f $(DV_UVMT_PATH)/uvmt_$(CV_CORE_LC).flist
 VLOG_FLAGS += $(DPILIB_VLOG_OPT)
 
 # Add the ISS to compilation
-VLOG_FLAGS += "+define+$(CV_CORE_UC)_TRACE_EXECUTION"
 VLOG_FLAGS += "+define+$(CV_CORE_UC)_RVFI"
-VLOG_FLAGS += "+define+$(CV_CORE_UC)_RVFI_TRACE_EXECUTION"
+
+ifeq ($(call IS_YES,$(ENABLE_TRACE_LOG)),YES)
+    VLOG_FLAGS += "+define+$(CV_CORE_UC)_TRACE_EXECUTION"
+    VLOG_FLAGS += "+define+$(CV_CORE_UC)_RVFI_TRACE_EXECUTION"
+endif
+
 VLOG_FLAGS += "+define+$(CV_CORE_UC)_CORE_LOG"
 VLOG_FLAGS += "+define+UVM"
 ifeq ($(call IS_YES,$(USE_ISS)),YES)

--- a/mk/uvmt/xrun.mk
+++ b/mk/uvmt/xrun.mk
@@ -122,9 +122,9 @@ endif
 ################################################################################
 # Waveform (post-process) command line
 ifeq ($(call IS_YES,$(ADV_DEBUG)),YES)
-WAVES_CMD = cd $(SIM_RUN_RESULTS) && $(INDAGO) -db ida.db
+WAVES_CMD = cd $(SIM_RUN_RESULTS) && $(INDAGO) -db ida.db &
 else
-WAVES_CMD = cd $(SIM_RUN_RESULTS) && $(SIMVISION) waves.shm
+WAVES_CMD = cd $(SIM_RUN_RESULTS) && $(SIMVISION) waves.shm &
 endif
 
 XRUN_USER_COMPILE_ARGS += $(USER_COMPILE_FLAGS)
@@ -180,9 +180,13 @@ endif
 XRUN_UVM_MACROS_INC_FILE = $(DV_UVMT_PATH)/uvmt_$(CV_CORE_LC)_uvm_macros_inc.sv
 
 XRUN_FILE_LIST ?= -f $(DV_UVMT_PATH)/uvmt_$(CV_CORE_LC).flist
-XRUN_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_TRACE_EXECUTION
 XRUN_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_RVFI
-XRUN_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_RVFI_TRACE_EXECUTION
+
+ifeq ($(call IS_YES,$(ENABLE_TRACE_LOG)),YES)
+    XRUN_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_TRACE_EXECUTION
+    XRUN_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_RVFI_TRACE_EXECUTION
+endif
+
 XRUN_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_CORE_LOG
 XRUN_USER_COMPILE_ARGS += +define+UVM
 ifeq ($(call IS_YES,$(USE_ISS)),YES)


### PR DESCRIPTION
Updates in this PR:

1. added new tb config "+disable_all_trn_logs" to all disabling all TB logging
2. added a test-cfg yaml corresponding to this
3. Update all make files with new variable ENABLE_TRACE_LOG , controlling including/excluding core defines which instantates tracer and corresponding tracer logging. Defaults to enable. To disable add ENABLE_TRACE_LOG=NO to simulation make command.