### PR TITLE
FPU FCOV

### DIFF
--- a/cv32e40p/env/uvme/cov/uvme_cv32e40p_cov_model.sv
+++ b/cv32e40p/env/uvme/cov/uvme_cv32e40p_cov_model.sv
@@ -29,10 +29,12 @@ class uvme_cv32e40p_cov_model_c extends uvm_component;
    uvme_cv32e40p_cfg_c    cfg;
    uvme_cv32e40p_cntxt_c  cntxt;
 
-   uvme_rv32isa_covg        isa_covg; 
-   uvme_interrupt_covg      interrupt_covg;
-   uvme_debug_covg          debug_covg;
-   uvme_rv32x_hwloop_covg   rv32x_hwloop_covg;
+   uvme_rv32isa_covg                    isa_covg;
+   uvme_interrupt_covg                  interrupt_covg;
+   uvme_debug_covg                      debug_covg;
+   uvme_rv32x_hwloop_covg               rv32x_hwloop_covg;
+   uvme_cv32e40p_fp_instr_covg          cv32e40p_fp_instr_covg;
+   uvme_cv32e40p_zfinx_instr_covg       cv32e40p_zfinx_instr_covg;
 
    `uvm_component_utils_begin(uvme_cv32e40p_cov_model_c)
       `uvm_field_object(cfg  , UVM_DEFAULT)
@@ -112,6 +114,16 @@ function void uvme_cv32e40p_cov_model_c::build_phase(uvm_phase phase);
    uvm_config_db#(uvme_cv32e40p_cntxt_c)::set(this, "debug_covg", "cntxt", cntxt);
    
    rv32x_hwloop_covg = uvme_rv32x_hwloop_covg::type_id::create("rv32x_hwloop_covg", this);
+
+   if( (cfg.rv32f_fcov_en == 1) && (cfg.zfinx_fcov_en == 0) ) begin
+      cv32e40p_fp_instr_covg = uvme_cv32e40p_fp_instr_covg::type_id::create("cv32e40p_fp_instr_covg", this);
+      uvm_config_db#(uvme_cv32e40p_cntxt_c)::set(this, "cv32e40p_fp_instr_covg", "cntxt", cntxt);
+   end else if ( (cfg.zfinx_fcov_en == 1) && (cfg.rv32f_fcov_en == 0) ) begin
+      cv32e40p_zfinx_instr_covg = uvme_cv32e40p_zfinx_instr_covg::type_id::create("cv32e40p_zfinx_instr_covg", this);
+      uvm_config_db#(uvme_cv32e40p_cntxt_c)::set(this, "cv32e40p_zfinx_instr_covg", "cntxt", cntxt);
+   end else if ( (cfg.rv32f_fcov_en == 1) && (cfg.zfinx_fcov_en == 1) ) begin
+      `uvm_fatal("FCOV", "Illegal Config with FCOV enable for both RV32F and RV32ZFINX")
+   end
 
 endfunction : build_phase
 

--- a/cv32e40p/env/uvme/cov/uvme_cv32e40p_fp_instr_covg.sv
+++ b/cv32e40p/env/uvme/cov/uvme_cv32e40p_fp_instr_covg.sv
@@ -1,0 +1,766 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright 2023 OpenHW Group
+// Copyright 2023 Dolphin Design
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+//
+///////////////////////////////////////////////////////////////////////////////
+
+class uvme_cv32e40p_fp_instr_covg extends uvm_component;
+    /*
+    * Class members
+    */
+    uvme_cv32e40p_cfg_c    cfg;
+    uvme_cv32e40p_cntxt_c  cntxt;
+
+    `uvm_component_utils_begin(uvme_cv32e40p_fp_instr_covg)
+      `uvm_field_object(cfg  , UVM_DEFAULT)
+      `uvm_field_object(cntxt, UVM_DEFAULT)
+    `uvm_component_utils_end
+
+    extern function new(string name = "cv32e40p_fp_instr_covg", uvm_component parent = null);
+    extern function void build_phase(uvm_phase phase);
+    extern task run_phase(uvm_phase phase);
+    extern task sample_clk_i();
+
+    `define FPU_LAT_0_2_EX_REGFILE_ALU_WR_NO_STALL_COND \
+     (cp_is_mulh_ex == 0) & (cp_is_misaligned_data_req_ex == 0) & (cp_is_post_inc_ld_st_inst_ex == 0) & (cp_ex_apu_valid_memorised == 0)
+
+    `define FPU_MULTICYCLE_WINDOW_ILLEGAL_CASES \
+     illegal_bins clk_2_19_group_NON_DIVSQRT  = ( (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1}) ) \
+                                                   with ( (cp_f_multicycle_clk_window != 0) & (fpu_latency == 0) & `FPU_LAT_0_2_EX_REGFILE_ALU_WR_NO_STALL_COND ); \
+     illegal_bins clk_3_19_group_NON_DIVSQRT  = ( (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1, 2}) ) \
+                                                   with ( (cp_f_multicycle_clk_window != 0) & (fpu_latency == 1) & `FPU_LAT_0_2_EX_REGFILE_ALU_WR_NO_STALL_COND ); \
+     illegal_bins clk_4_19_group_NON_DIVSQRT  = ( (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1, 2, 3}) ) \
+                                                   with ( (cp_f_multicycle_clk_window != 0) & (fpu_latency == 2) & `FPU_LAT_0_2_EX_REGFILE_ALU_WR_NO_STALL_COND );
+
+    `define FPU_ZERO_LATENCY_ILLEGAL_BUSY \
+     illegal_bins apu_busy_curr_apu_op_not_div_sqrt = ( !binsof(cp_curr_fpu_apu_op_multicycle) intersect {APU_OP_FDIV, APU_OP_FSQRT} ) \
+                                                      with ( ((cp_curr_fpu_apu_op_multicycle + 1) * (fpu_latency == 0)) != 0 );
+
+    `define IGNORE_BINS_NON_FD_F_INSTR \
+     ignore_bins non_fd_f_inst = binsof(cp_curr_fpu_apu_op) intersect {`APU_INSTR_WITH_NO_FD};
+
+    `define IGNORE_BINS_ZERO_LAT_FPU_OP \
+     ignore_bins zero_lat_inst = ( !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT} ) \
+                                 with ( ((cp_curr_fpu_apu_op + 1) * (fpu_latency == 0)) != 0 );
+
+    `define IGNORE_BINS_CONTENTION_IN_LSU_WITH_APU \
+     ignore_bins in_contention_lsu_wr = ( binsof(cp_apu_contention) intersect {1} ) \
+                                        with ( ((cp_curr_fpu_apu_op + 1) * (fpu_latency == 1)) != 0 );
+
+    `define IGNORE_BINS_NON_FS3_F_INSTR \
+     ignore_bins non_fs3_f_inst = !binsof(cp_id_stage_f_inst) intersect {`RV32F_INSTR_WITH_NO_FS3};
+
+    `define IGNORE_BINS_NON_RD_F_INSTR \
+     ignore_bins non_rd_f_inst = !binsof(cp_curr_fpu_apu_op) intersect {`APU_INSTR_WITH_NO_FD};
+
+    `define IGNORE_BINS_NON_RS_F_INSTR_IN_ID \
+     ignore_bins non_rs_id_stage_f_inst = !binsof(cp_id_stage_f_inst) intersect {APU_OP_I2F, APU_OP_I2F_U};
+
+    `define IGNORE_BINS_NON_RS1_CV32E40P_INSTR \
+     ignore_bins non_rs1_rv32_instr = binsof(cp_id_stage_non_rv32fc_inst) intersect {TB_OPCODE_LUI,TB_OPCODE_AUIPC,TB_OPCODE_JAL};
+
+    `define IGNORE_BINS_NON_RS2_CV32E40P_INSTR \
+     ignore_bins non_rs2_rv32_instr = binsof(cp_id_stage_non_rv32fc_inst) intersect {`RV32_INSTR_WITH_NO_RS2};
+
+    `define IGNORE_BINS_NON_STALLED_CONTENTION_WR_STATE \
+     ignore_bins non_stalled_contention_wr_state = binsof(cp_contention_state) intersect {0,1};
+
+    `define IGNORE_BINS_NON_FD_F_INSTR_AT_CONTENTION \
+     ignore_bins non_fd_f_inst = binsof(cp_last_fpu_apu_op_at_contention) intersect {`APU_INSTR_WITH_NO_FD};
+
+    `define IGNORE_BINS_CONTENTION_AT_LSU_REGFILE_WR \
+     ignore_bins contention_at_lsu_wr = binsof(cp_apu_contention) intersect {1};
+
+    `define IGNORE_BINS_NON_RD_F_INSTR_AT_CONTENTION \
+     ignore_bins non_rd_f_inst = !binsof(cp_last_fpu_apu_op_at_contention) intersect {`APU_INSTR_WITH_NO_FD};
+
+    `define IGNORE_BINS_NO_CONTENTION \
+     ignore_bins no_contention = binsof(cp_apu_contention) intersect {1};
+
+    `define IGNORE_BINS_NO_CONTENTION_LSU \
+     ignore_bins no_contention_lsu_wr = binsof(cp_apu_contention) intersect {0};
+
+    `define CP_FOR_USE_WITH_WITH_CONSTRUCT_EXCLUDING_SPECIAL_CASES \
+     cp_is_mulh_ex, cp_is_misaligned_data_req_ex, cp_is_post_inc_ld_st_inst_ex, cp_ex_apu_valid_memorised
+
+    /*
+    * Covergroups
+    */
+
+    covergroup cg_f_multicycle(int fpu_latency);
+        `per_instance_fcov
+        option.at_least = 10;
+
+        cp_if_stage_f_inst : coverpoint `COVIF_CB.if_stage_instr_rdata_i iff (`COVIF_CB.if_stage_instr_rvalid_i == 1) {
+            `RV32F_INSTR_BINS
+            option.weight = 5;
+        }
+
+        cp_id_stage_f_inst : coverpoint `COVIF_CB.id_stage_instr_rdata_i iff (`COVIF_CB.id_stage_instr_valid_i == 1) {
+            `RV32F_INSTR_BINS
+            option.weight = 5;
+        }
+
+        cp_id_stage_apu_op_ex_o : coverpoint `COVIF_CB.id_stage_apu_op_ex_o iff (`COVIF_CB.id_stage_apu_en_ex_o == 1) {
+            `FPU_OP_BINS
+            option.weight = 5;
+        }
+
+        cp_f_multicycle_clk_window : coverpoint cntxt.cov_vif.if_clk_cycle_window {
+            bins clk1 = {1};
+            bins clk2 = {2};
+            bins clk3 = {3};
+            bins clk4 = {4};
+            bins clk5 = {5};
+            bins clk6 = {6};
+            bins clk7 = {7};
+            bins clk8 = {8};
+            bins clk9 = {9};
+            bins clk10 = {10};
+            bins clk11 = {11};
+            bins clk12 = {12};
+            bins clk13 = {13};
+            bins clk14 = {14};
+            bins clk15 = {15};
+            bins clk16 = {16};
+            bins clk17 = {17};
+            bins clk18 = {18};
+            bins clk19 = {19};
+            ignore_bins ignore_idle = {0};
+            illegal_bins clk_more_than_19 = {[20:31]};
+        }
+
+        cp_id_stage_inst_valid : coverpoint `COVIF_CB.id_stage_instr_valid_i {
+            bins id_stage_instr_valid = {1};
+            option.weight = 1;
+        }
+
+        cp_if_stage_inst_valid : coverpoint `COVIF_CB.if_stage_instr_rvalid_i {
+            bins if_stage_instr_valid = {1};
+            option.weight = 1;
+        }
+
+        cp_id_stage_apu_en_ex_o : coverpoint `COVIF_CB.id_stage_apu_en_ex_o {
+            bins id_stage_apu_en_ex_1 = {1};
+            bins id_stage_apu_en_ex_0_to_1 = (0 => 1);
+            option.weight = 1;
+        }
+
+        cp_apu_req_valid : coverpoint `COVIF_CB.apu_req {
+            bins apu_req_valid = {1'b1};
+            option.weight = 1;
+        }
+
+        cp_apu_grant_valid : coverpoint `COVIF_CB.apu_gnt {
+            bins apu_gnt_valid = {1'b1};
+            option.weight = 1;
+        }
+
+        cp_apu_busy : coverpoint `COVIF_CB.apu_busy {
+            bins apu_busy_high = {1'b1};
+            option.weight = 1;
+        }
+
+        cp_curr_fpu_apu_op : coverpoint cntxt.cov_vif.o_curr_fpu_apu_op_if {
+            `FPU_OP_BINS
+            option.weight = 5;
+        }
+
+        cp_curr_fpu_apu_op_at_apu_req : coverpoint cntxt.cov_vif.o_curr_fpu_apu_op_if iff ( (`COVIF_CB.apu_req == 1) &&
+                                                                                            (`COVIF_CB.apu_gnt == 1) )
+        {
+            `FPU_OP_BINS
+            option.weight = 5;
+        }
+
+        cp_curr_fpu_apu_op_multicycle : coverpoint cntxt.cov_vif.o_curr_fpu_apu_op_if iff (`COVIF_CB.apu_busy == 1)
+        {
+            `FPU_OP_BINS
+            option.weight = 5;
+        }
+
+        cp_is_mulh_ex : coverpoint cntxt.cov_vif.is_mulh_ex {
+            bins not_mulh = {1'b0};
+            option.weight = 1;
+        }
+
+        cp_is_misaligned_data_req_ex : coverpoint cntxt.cov_vif.is_misaligned_data_req_ex {
+            bins not_misaligned_data_req_ex = {1'b0};
+            option.weight = 1;
+        }
+
+        cp_is_post_inc_ld_st_inst_ex : coverpoint cntxt.cov_vif.is_post_inc_ld_st_inst_ex {
+            bins not_post_inc_ld_st_inst_ex = {1'b0};
+            option.weight = 1;
+        }
+
+        cp_ex_apu_valid_memorised : coverpoint cntxt.cov_vif.ex_apu_valid_memorised {
+            bins not_apu_valid_mem = {1'b0};
+            option.weight = 1;
+        }
+
+        // cross coverage for F-inst in ID-stage with preceeding F-multicycle instr
+        cr_f_inst_at_id_stage_inp_with_fpu_multicycle_req : cross cp_id_stage_f_inst,
+                                                                  cp_curr_fpu_apu_op_at_apu_req
+        {option.weight = 50;}
+
+        // cross coverage for F-inst in ID-stage with preceeding F-multicycle
+        // case with apu_busy or APU needing more than 1 clock cycle 
+        cr_f_inst_at_id_stage_inp_while_fpu_busy : cross cp_id_stage_f_inst,
+                                                         cp_curr_fpu_apu_op_multicycle {
+            option.weight = 50;
+            // For FPU config with Latency=0 , apu_busy is expected to be set only for FDIV and FSQRT case
+            `FPU_ZERO_LATENCY_ILLEGAL_BUSY
+        }
+
+        // cross coverage for F-inst arriving at ID-stage input at various stages of APU latency
+        // clk-cycles of the ongoing/preceeding F-multicycle instr
+        cr_f_inst_at_id_stage_inp_with_cyc_window_of_ongoing_fpu_calc : cross cp_id_stage_f_inst,
+                                                                              cp_f_multicycle_clk_window,
+                                                                              cp_curr_fpu_apu_op,
+                                                                              `CP_FOR_USE_WITH_WITH_CONSTRUCT_EXCLUDING_SPECIAL_CASES {
+            option.weight = 50;
+            `FPU_MULTICYCLE_WINDOW_ILLEGAL_CASES
+        }
+
+        // cross coverage for F-inst at ID-stage output with preceeding F-multicycle instr
+        // Note: Added 2 separate similar cross coverages ID stage because of different
+        // arrival times of next instruction w.r.t APU Req
+        cr_f_inst_at_id_stage_out_with_fpu_multicycle_req : cross cp_id_stage_apu_op_ex_o,
+                                                                  cp_curr_fpu_apu_op_at_apu_req
+        {option.weight = 50;}
+
+        // cross coverage for F-inst at ID-stage output with preceeding F-multicycle
+        // case with apu_busy or APU needing more than 1 clock cycle 
+        // Note: Added 2 separate similar cross coverages ID stage because of different
+        // arrival times of next instruction w.r.t APU Req
+        cr_f_inst_at_id_stage_out_while_fpu_busy : cross cp_id_stage_apu_op_ex_o,
+                                                         cp_curr_fpu_apu_op_multicycle {
+            option.weight = 50;
+            `FPU_ZERO_LATENCY_ILLEGAL_BUSY
+        }
+
+        // cross coverage for F-inst arriving at ID-stage output at various stages of APU latency
+        // clk-cycles of the ongoing/preceeding F-multicycle instr
+        // Note: Added 2 separate similar cross coverages ID stage because of different
+        // arrival times of next instruction w.r.t APU Req
+        cr_f_inst_at_id_stage_out_with_cyc_window_of_ongoing_fpu_calc : cross cp_id_stage_apu_op_ex_o,
+                                                                              cp_f_multicycle_clk_window,
+                                                                              cp_curr_fpu_apu_op,
+                                                                              `CP_FOR_USE_WITH_WITH_CONSTRUCT_EXCLUDING_SPECIAL_CASES {
+
+            option.weight = 50;
+            `FPU_MULTICYCLE_WINDOW_ILLEGAL_CASES
+        }
+
+        // cross coverage for F-inst at IF-stage with preceeding F-multicycle instr
+        cr_f_inst_at_if_stage_inp_with_fpu_multicycle_req : cross cp_if_stage_f_inst,
+                                                                  cp_curr_fpu_apu_op_at_apu_req
+        {option.weight = 50;}
+
+        // cross coverage for F-inst at IF-stage with preceeding F-multicycle
+        // case with apu_busy or APU needing more than 1 clock cycle 
+        cr_f_inst_at_if_stage_inp_while_fpu_busy : cross cp_if_stage_f_inst,
+                                                         cp_curr_fpu_apu_op_multicycle {
+            option.weight = 50;
+            `FPU_ZERO_LATENCY_ILLEGAL_BUSY
+        }
+
+        // cross coverage for F-inst arriving at IF-stage output at various stages of
+        // APU latency clk-cycles of the ongoing/preceeding F-multicycle instr
+        cr_f_inst_at_if_stage_inp_with_cyc_window_of_ongoing_fpu_calc : cross cp_if_stage_f_inst,
+                                                                              cp_f_multicycle_clk_window,
+                                                                              cp_curr_fpu_apu_op,
+                                                                              `CP_FOR_USE_WITH_WITH_CONSTRUCT_EXCLUDING_SPECIAL_CASES {
+
+            option.weight = 50;
+            `FPU_MULTICYCLE_WINDOW_ILLEGAL_CASES
+        }
+
+    endgroup : cg_f_multicycle
+
+
+    covergroup cg_f_inst_reg(int fpu_latency);
+        `per_instance_fcov
+
+        cp_apu_req_valid : coverpoint `COVIF_CB.apu_req {
+            bins apu_req_valid = {1'b1};
+            option.weight = 1;
+        }
+
+        cp_apu_grant_valid : coverpoint `COVIF_CB.apu_gnt {
+            bins apu_gnt_valid = {1'b1};
+            option.weight = 1;
+        }
+
+        cp_apu_busy : coverpoint `COVIF_CB.apu_busy {
+            bins apu_busy_high = {1'b1};
+            option.weight = 1;
+        }
+
+        cp_id_inst_valid : coverpoint `COVIF_CB.id_stage_instr_valid_i {
+            bins id_stage_instr_valid = {1};
+            option.weight = 1;
+        }
+
+        cp_apu_rvalid : coverpoint `COVIF_CB.apu_rvalid_i {
+            bins apu_rvalid = {1};
+            option.weight = 1;
+        }
+
+        cp_apu_contention : coverpoint `COVIF_CB.apu_perf_wb_o {
+            bins no_contention = {0};
+            bins has_contention = {1};
+            option.weight = 1;
+        }
+
+        cp_curr_fpu_apu_op : coverpoint cntxt.cov_vif.o_curr_fpu_apu_op_if {
+            `FPU_OP_BINS
+            option.weight = 5;
+        }
+
+        cp_last_fpu_apu_op_at_contention : coverpoint cntxt.cov_vif.o_last_fpu_apu_op_if {
+            bins curr_apu_op_fmadd        =    {APU_OP_FMADD}       with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fnmsub       =    {APU_OP_FNMSUB}      with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fadd         =    {APU_OP_FADD}        with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fmul         =    {APU_OP_FMUL}        with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fdiv         =    {APU_OP_FDIV}        with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fsqrt        =    {APU_OP_FSQRT}       with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fsgnj        =    {APU_OP_FSGNJ}       with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fminmax      =    {APU_OP_FMINMAX}     with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fcmp         =    {APU_OP_FCMP}        with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fclassify    =    {APU_OP_FCLASSIFY}   with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_f2f          =    {APU_OP_F2F}         with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_f2i          =    {APU_OP_F2I}         with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_i2f          =    {APU_OP_I2F}         with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fmsub        =    {APU_OP_FMSUB}       with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fnmadd       =    {APU_OP_FNMADD}      with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fsub         =    {APU_OP_FSUB}        with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fsgnj_se     =    {APU_OP_FSGNJ_SE}    with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_f2i_u        =    {APU_OP_F2I_U}       with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_i2f_u        =    {APU_OP_I2F_U}       with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            option.weight = 5;
+        }
+
+        // TODO: need to add another cover point for F-inst at ID-EX boundary ?
+        cp_id_stage_f_inst : coverpoint `COVIF_CB.id_stage_instr_rdata_i {
+            `RV32F_INSTR_BINS
+            option.weight = 5;
+        }
+
+        // TODO: to add rv32c coverage
+        cp_id_stage_non_rv32fc_inst : coverpoint `COVIF_CB.id_stage_instr_rdata_i[6:0] {
+            `CV32E40P_INSTR_OPCODE_BIT_6_0_BINS__NO_RV32C_FC
+            option.weight = 5;
+        }
+
+        cp_id_f_inst_fs1 : coverpoint `COVIF_CB.id_stage_instr_rdata_i[19:15] {
+            bins fs1[] = {[0:31]};
+            option.weight = 1;
+        }
+        cp_id_f_inst_fs2 : coverpoint `COVIF_CB.id_stage_instr_rdata_i[24:20] {
+            bins fs2[] = {[0:31]};
+            option.weight = 1;
+        }
+        cp_curr_fpu_inst_fd : coverpoint cntxt.cov_vif.curr_fpu_fd {
+            bins fd[] = {[0:31]};
+            option.weight = 1;
+        }
+        cp_curr_fpu_inst_rd : coverpoint cntxt.cov_vif.curr_fpu_rd {
+            bins rd[] = {[0:31]};
+            option.weight = 1;
+        }
+        cp_id_x_inst_rs1 : coverpoint `COVIF_CB.id_stage_instr_rdata_i[19:15] {
+            bins rs1[] = {[0:31]};
+            option.weight = 1;
+        }
+        cp_apu_alu_contention_wr_rd : coverpoint cntxt.cov_vif.curr_rd_at_ex_regfile_wr_contention {
+            bins rd[] = {[0:31]}                        with ( ((item + 1) * (fpu_latency != 1)) != 0 );
+            illegal_bins rd_addr_32_63 = {[32:63]}      with ( ((item + 1) * (fpu_latency != 1)) != 0 );
+            option.weight = 1;
+        }
+        cp_lsu_apu_contention_wr_rd : coverpoint cntxt.cov_vif.curr_rd_at_wb_regfile_wr_contention {
+            bins rd[] = {[0:31]}                        with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            illegal_bins rd_addr_32_63 = {[32:63]}      with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            option.weight = 1;
+        }
+        cp_prev_rd_waddr_contention : coverpoint cntxt.cov_vif.prev_rd_waddr_contention {
+            bins rd[] = {[0:63]};
+            option.weight = 1;
+        }
+
+        cp_contention_state : coverpoint cntxt.cov_vif.contention_state {
+            bins no_contention = {0};
+            bins contention_1st_cyc_done = {1};
+            bins contention_2nd_cyc_done = {2};
+            ignore_bins state3 = {3};
+            option.weight = 1;
+        }
+
+        cp_b2b_contention : coverpoint cntxt.cov_vif.b2b_contention {
+            bins b2b_contention_true = {1};
+            option.weight = 5;
+        }
+
+        cp_fd_fs1_eq : coverpoint (`COVIF_CB.id_stage_instr_rdata_i[19:15] == cntxt.cov_vif.curr_fpu_fd) {
+            bins fd_fs1_equal = {1};
+        }
+        cp_fd_fs2_eq : coverpoint (`COVIF_CB.id_stage_instr_rdata_i[24:20] == cntxt.cov_vif.curr_fpu_fd) {
+            bins fd_fs2_equal = {1};
+        }
+        cp_fd_fs3_eq : coverpoint (`COVIF_CB.id_stage_instr_rdata_i[31:27] == cntxt.cov_vif.curr_fpu_fd) {
+            bins fd_fs3_equal = {1};
+        }
+        cp_rd_rs1_eq : coverpoint (`COVIF_CB.id_stage_instr_rdata_i[19:15] == cntxt.cov_vif.curr_fpu_rd) {
+            bins rd_rs1_equal = {1};
+        }
+        cp_rd_rs2_eq : coverpoint (`COVIF_CB.id_stage_instr_rdata_i[24:20] == cntxt.cov_vif.curr_fpu_rd) {
+            bins rd_rs1_equal = {1};
+        }
+
+        //*********************************************************************************************************
+        //     Cross Cov description for reg-to-reg dependency cases in instr sequence with F-multicycle instr
+        //*********************************************************************************************************
+        // This Cross Coverage captures the cases where latest APU execution's RD addr is same as
+        // rs1/rs2/rs3 of the next instruction in pipeline.
+        // Design is expected to stall EX in such scenarios until the previous instruction retires.
+        // The test scenarios are captured for correct RTL behavior, expecting EX stall in such cases.
+        // And for any conflicting design behaviour with EX proceeding without stalls, tests rely on Ref model
+        // to flag the resulting errors.
+        
+        //*********************************************************************************************************
+        // CASES WITH/WITHOUT CONTENTION AT THE TIME OF APU RESULT WRITE TO REGFILE
+        // WHERE APU WRITE WILL WIN (APU LATENCY = 0,2,3,4)
+        //*********************************************************************************************************
+
+        // cross coverage for F-instr following F-instr with fd to fs1 dependency - case with APU latency > 0
+        cr_fd_fs1_eq_nonzero_lat : cross cp_fd_fs1_eq, cp_id_inst_valid,
+                                         cp_id_stage_f_inst, cp_apu_busy,
+                                         cp_apu_rvalid, cp_curr_fpu_inst_fd,
+                                         cp_curr_fpu_apu_op, cp_apu_contention {
+
+            option.weight = 50;
+            `IGNORE_BINS_NON_FD_F_INSTR
+            `IGNORE_BINS_ZERO_LAT_FPU_OP
+            `IGNORE_BINS_CONTENTION_IN_LSU_WITH_APU
+        }
+
+        // cross coverage for F-instr following F-instr with fd to fs2 dependency - case with APU latency > 0
+        cr_fd_fs2_eq_nonzero_lat : cross cp_fd_fs2_eq, cp_id_inst_valid,
+                                         cp_id_stage_f_inst, cp_apu_busy,
+                                         cp_apu_rvalid, cp_curr_fpu_inst_fd,
+                                         cp_curr_fpu_apu_op, cp_apu_contention {
+
+            option.weight = 50;
+            `IGNORE_BINS_NON_FD_F_INSTR
+            `IGNORE_BINS_ZERO_LAT_FPU_OP
+            `IGNORE_BINS_CONTENTION_IN_LSU_WITH_APU
+        }
+
+        // cross coverage for F-instr following F-instr with fd to fs3 dependency - case with APU latency > 0
+        cr_fd_fs3_eq_nonzero_lat : cross cp_fd_fs3_eq, cp_id_inst_valid,
+                                         cp_id_stage_f_inst, cp_apu_busy,
+                                         cp_apu_rvalid, cp_curr_fpu_inst_fd,
+                                         cp_curr_fpu_apu_op, cp_apu_contention {
+
+            option.weight = 50;
+            `IGNORE_BINS_NON_FD_F_INSTR
+            `IGNORE_BINS_ZERO_LAT_FPU_OP
+            `IGNORE_BINS_CONTENTION_IN_LSU_WITH_APU
+            `IGNORE_BINS_NON_FS3_F_INSTR
+        }
+
+        // cross coverage for F-instr following F-instr with rd to rs1 dependency - case with APU latency > 0
+        cr_rd_rs1_eq_nonzero_lat  :  cross cp_rd_rs1_eq, cp_id_inst_valid,
+                                           cp_id_stage_f_inst, cp_apu_busy,
+                                           cp_apu_rvalid, cp_curr_fpu_inst_rd,
+                                           cp_curr_fpu_apu_op, cp_apu_contention {
+
+            option.weight = 50;
+            `IGNORE_BINS_ZERO_LAT_FPU_OP
+            `IGNORE_BINS_CONTENTION_IN_LSU_WITH_APU
+            `IGNORE_BINS_NON_RD_F_INSTR
+            `IGNORE_BINS_NON_RS_F_INSTR_IN_ID
+        }
+
+        // cross coverage for Non F-instr following F-instr with rd to rs1 dependency - case with APU latency > 0
+        cr_rv32f_rd_non_rv32f_rs1_eq_nonzero_lat : cross cp_rd_rs1_eq, cp_id_inst_valid,
+                                                         cp_id_stage_non_rv32fc_inst,
+                                                         cp_apu_busy, cp_apu_rvalid,
+                                                         cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op,
+                                                         cp_apu_contention {
+
+            option.weight = 50;
+            `IGNORE_BINS_ZERO_LAT_FPU_OP
+            `IGNORE_BINS_CONTENTION_IN_LSU_WITH_APU
+            `IGNORE_BINS_NON_RD_F_INSTR
+            `IGNORE_BINS_NON_RS1_CV32E40P_INSTR
+        }
+
+        // cross coverage for Non F-instr following F-instr with rd to rs2 dependency - case with APU latency > 0
+        cr_rv32f_rd_non_rv32f_rs2_eq_nonzero_lat : cross cp_rd_rs2_eq, cp_id_inst_valid,
+                                                         cp_id_stage_non_rv32fc_inst,
+                                                         cp_apu_busy, cp_apu_rvalid,
+                                                         cp_curr_fpu_inst_rd,
+                                                         cp_curr_fpu_apu_op,
+                                                         cp_apu_contention {
+
+            option.weight = 50;
+            `IGNORE_BINS_ZERO_LAT_FPU_OP
+            `IGNORE_BINS_CONTENTION_IN_LSU_WITH_APU
+            `IGNORE_BINS_NON_RD_F_INSTR
+            `IGNORE_BINS_NON_RS2_CV32E40P_INSTR
+        }
+
+        // cross coverage for contention case 2nd cycle with ALU regfile write
+        cr_waddr_rd_apu_alu_ex_contention : cross cp_apu_alu_contention_wr_rd,
+                                                  cp_contention_state,
+                                                  cp_apu_contention {
+            bins main_cr_bin = cr_waddr_rd_apu_alu_ex_contention with ((cp_contention_state <= 3) & (fpu_latency != 1));
+
+            `IGNORE_BINS_NON_STALLED_CONTENTION_WR_STATE
+            `IGNORE_BINS_NO_CONTENTION
+        }
+
+
+        //*********************************************************************************************************
+        // CASES WITH/WITHOUT CONTENTION AT APU RESULT WRITE TO REGFILE. APU_LATENCY=0 PRIOIRTY APU WRITE WINS
+        //*********************************************************************************************************
+
+        // cross coverage for F-instr following F-instr with fd to fs1 dependency - 0 Latency
+        cr_fd_fs1_eq_no_lat  :  cross cp_fd_fs1_eq, cp_apu_req_valid, cp_id_stage_f_inst,
+                                      cp_apu_grant_valid, cp_apu_rvalid, cp_curr_fpu_inst_fd,
+                                      cp_curr_fpu_apu_op, cp_apu_contention {
+            option.weight = 50;
+            bins main_cr_bin = cr_fd_fs1_eq_no_lat with ( (cp_apu_rvalid == 1) & (fpu_latency == 0) );
+
+            `IGNORE_BINS_NON_FD_F_INSTR
+        }
+
+        // cross coverage for F-instr following F-instr with fd to fs2 dependency - 0 Latency
+        cr_fd_fs2_eq_no_lat  :  cross cp_fd_fs2_eq, cp_apu_req_valid, cp_id_stage_f_inst,
+                                      cp_apu_grant_valid, cp_apu_rvalid, cp_curr_fpu_inst_fd,
+                                      cp_curr_fpu_apu_op, cp_apu_contention {
+            option.weight = 50;
+            bins main_cr_bin = cr_fd_fs2_eq_no_lat with ( (cp_apu_rvalid == 1) & (fpu_latency == 0) );
+
+            `IGNORE_BINS_NON_FD_F_INSTR
+        }
+
+        // cross coverage for F-instr following F-instr with fd to fs3 dependency - 0 Latency
+        cr_fd_fs3_eq_no_lat  :  cross cp_fd_fs3_eq, cp_apu_req_valid, cp_id_stage_f_inst,
+                                      cp_apu_grant_valid, cp_apu_rvalid, cp_curr_fpu_inst_fd,
+                                      cp_curr_fpu_apu_op, cp_apu_contention {
+            option.weight = 50;
+            bins main_cr_bin =  cr_fd_fs3_eq_no_lat with ( (cp_apu_rvalid == 1) & (fpu_latency == 0) );
+
+            `IGNORE_BINS_NON_FD_F_INSTR
+            `IGNORE_BINS_NON_FS3_F_INSTR
+        }
+
+        // cross coverage for F-instr following F-instr with rd to rs1 dependency - 0 Latency
+        cr_rd_rs1_eq_no_lat  :  cross cp_rd_rs1_eq, cp_id_inst_valid, cp_id_stage_f_inst,
+                                      cp_apu_req_valid, cp_apu_grant_valid, cp_apu_rvalid,
+                                      cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op, cp_apu_contention {
+            option.weight = 50;
+            bins main_cr_bin =  cr_rd_rs1_eq_no_lat with ( (cp_apu_rvalid == 1) & (fpu_latency == 0) );
+
+            `IGNORE_BINS_NON_RD_F_INSTR
+            `IGNORE_BINS_NON_RS_F_INSTR_IN_ID
+        }
+
+        // cross coverage for Non F-instr following F-instr with rd to rs1 dependency - 0 Latency
+        cr_rv32f_rd_non_rv32fc_rs1_eq_no_lat  :  cross cp_rd_rs1_eq, cp_id_inst_valid,
+                                                       cp_id_stage_non_rv32fc_inst, cp_apu_req_valid,
+                                                       cp_apu_grant_valid, cp_apu_rvalid,
+                                                       cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op,
+                                                       cp_apu_contention {
+            option.weight = 50;
+            bins main_cr_bin =  cr_rv32f_rd_non_rv32fc_rs1_eq_no_lat with ( (cp_apu_rvalid == 1) & (fpu_latency == 0) );
+
+            `IGNORE_BINS_NON_RD_F_INSTR
+            `IGNORE_BINS_NON_RS1_CV32E40P_INSTR
+        }
+        // cross coverage for Non F-instr following F-instr with rd to rs2 dependency - 0 Latency
+        cr_rv32f_rd_non_rv32fc_rs2_eq_no_lat  :  cross cp_rd_rs2_eq, cp_id_inst_valid,
+                                                       cp_id_stage_non_rv32fc_inst,
+                                                       cp_apu_req_valid, cp_apu_grant_valid,
+                                                       cp_apu_rvalid, cp_curr_fpu_inst_rd,
+                                                       cp_curr_fpu_apu_op, cp_apu_contention {
+            option.weight = 50;
+            bins main_cr_bin = cr_rv32f_rd_non_rv32fc_rs2_eq_no_lat with ( (cp_apu_rvalid == 1) & (fpu_latency == 0) );
+
+            `IGNORE_BINS_NON_RD_F_INSTR
+            `IGNORE_BINS_NON_RS2_CV32E40P_INSTR
+        }
+
+        //*********************************************************************************************************
+        // CONTENTION DURING APU RESULT WRITE TO REGFILE WHERE APU RESULT WRITE STALLS. APU LATENCY = 1
+        //*********************************************************************************************************
+
+        // cp_apu_contention = 1 cases
+        // cp_contention_state = 1 indicates that there was contention in WB at LSU-APU regfile wr mux
+
+        // cross coverage for F-instr following F-instr with fd to fs1 dependency
+        // case with APU latency = 1 and contention with LSU
+        cr_fd_fs1_eq_nonzero_lat_with_contention : cross cp_fd_fs1_eq, cp_id_inst_valid,
+                                                         cp_id_stage_f_inst, cp_curr_fpu_inst_fd,
+                                                         cp_last_fpu_apu_op_at_contention,
+                                                         cp_contention_state, cp_apu_contention {
+            option.weight = 50;
+            bins main_cr_bin = cr_fd_fs1_eq_nonzero_lat_with_contention
+                               with ( (cp_id_inst_valid == 1) & (fpu_latency == 1) );
+
+            `IGNORE_BINS_NON_STALLED_CONTENTION_WR_STATE
+            `IGNORE_BINS_NON_FD_F_INSTR_AT_CONTENTION
+            `IGNORE_BINS_CONTENTION_AT_LSU_REGFILE_WR
+        }
+
+        // cross coverage for F-instr following F-instr with fd to fs2 dependency
+        // case with APU latency = 1 and contention with LSU
+        cr_fd_fs2_eq_nonzero_lat_with_contention : cross cp_fd_fs2_eq, cp_id_inst_valid,
+                                                         cp_id_stage_f_inst, cp_curr_fpu_inst_fd,
+                                                         cp_last_fpu_apu_op_at_contention,
+                                                         cp_contention_state, cp_apu_contention {
+            option.weight = 50;
+            bins main_cr_bin = cr_fd_fs2_eq_nonzero_lat_with_contention
+                               with ( (cp_id_inst_valid == 1) & (fpu_latency == 1) );
+
+            `IGNORE_BINS_NON_STALLED_CONTENTION_WR_STATE
+            `IGNORE_BINS_NON_FD_F_INSTR_AT_CONTENTION
+            `IGNORE_BINS_CONTENTION_AT_LSU_REGFILE_WR
+        }
+
+        // cross coverage for F-instr following F-instr with fd to fs3 dependency
+        // case with APU latency = 1 and contention with LSU
+        cr_fd_fs3_eq_nonzero_lat_with_contention : cross cp_fd_fs3_eq, cp_id_inst_valid,
+                                                         cp_id_stage_f_inst, cp_curr_fpu_inst_fd,
+                                                         cp_last_fpu_apu_op_at_contention,
+                                                         cp_contention_state, cp_apu_contention {
+            option.weight = 50;
+            bins main_cr_bin = cr_fd_fs3_eq_nonzero_lat_with_contention
+                               with ( (cp_id_inst_valid == 1) & (fpu_latency == 1) );
+
+            `IGNORE_BINS_NON_FS3_F_INSTR
+            `IGNORE_BINS_NON_STALLED_CONTENTION_WR_STATE
+            `IGNORE_BINS_NON_FD_F_INSTR_AT_CONTENTION
+            `IGNORE_BINS_CONTENTION_AT_LSU_REGFILE_WR
+        }
+
+        // cross coverage for F-instr following F-instr with rd to rs1 dependency
+        // case with APU latency = 1 and contention with LSU
+        cr_rd_rs1_eq_nonzero_lat_with_contention : cross cp_rd_rs1_eq, cp_id_inst_valid,
+                                                         cp_id_stage_f_inst, cp_curr_fpu_inst_rd,
+                                                         cp_last_fpu_apu_op_at_contention,
+                                                         cp_contention_state, cp_apu_contention {
+            option.weight = 50;
+            bins main_cr_bin = cr_rd_rs1_eq_nonzero_lat_with_contention
+                               with ( (cp_id_inst_valid == 1) & (fpu_latency == 1) );
+
+            `IGNORE_BINS_NON_STALLED_CONTENTION_WR_STATE
+            `IGNORE_BINS_CONTENTION_AT_LSU_REGFILE_WR
+            `IGNORE_BINS_NON_RD_F_INSTR_AT_CONTENTION
+        }
+
+        // cross coverage for Non F-instr following F-instr with rd to rs1 dependency
+        // case with APU latency = 1 and contention with LSU
+        cr_rv32f_rd_non_rv32fc_rs1_eq_nonzero_lat_with_contention : cross cp_rd_rs1_eq, cp_id_inst_valid,
+                                                                          cp_id_stage_non_rv32fc_inst,
+                                                                          cp_curr_fpu_inst_rd,
+                                                                          cp_last_fpu_apu_op_at_contention,
+                                                                          cp_contention_state,
+                                                                          cp_apu_contention {
+            option.weight = 50;
+            bins main_cr_bin = cr_rv32f_rd_non_rv32fc_rs1_eq_nonzero_lat_with_contention
+                               with ( (cp_id_inst_valid == 1) & (fpu_latency == 1) );
+
+            `IGNORE_BINS_NON_RS1_CV32E40P_INSTR
+            `IGNORE_BINS_NON_STALLED_CONTENTION_WR_STATE
+            `IGNORE_BINS_CONTENTION_AT_LSU_REGFILE_WR
+            `IGNORE_BINS_NON_RD_F_INSTR_AT_CONTENTION
+        }
+
+        // cross coverage for Non F-instr following F-instr with rd to rs2 dependency
+        // case with APU latency = 1 and contention with LSU
+        cr_rv32f_rd_non_rv32fc_rs2_eq_nonzero_lat_with_contention : cross cp_rd_rs2_eq, cp_id_inst_valid,
+                                                                          cp_id_stage_non_rv32fc_inst,
+                                                                          cp_curr_fpu_inst_rd,
+                                                                          cp_last_fpu_apu_op_at_contention,
+                                                                          cp_contention_state,
+                                                                          cp_apu_contention {
+            option.weight = 50;
+            bins main_cr_bin = cr_rv32f_rd_non_rv32fc_rs2_eq_nonzero_lat_with_contention
+                               with ( (cp_id_inst_valid == 1) & (fpu_latency == 1) );
+
+            `IGNORE_BINS_NON_RS2_CV32E40P_INSTR
+            `IGNORE_BINS_NON_STALLED_CONTENTION_WR_STATE
+            `IGNORE_BINS_CONTENTION_AT_LSU_REGFILE_WR
+            `IGNORE_BINS_NON_RD_F_INSTR_AT_CONTENTION
+        }
+
+        // TODO: does it require checking rd to rs1/rs2 equal in this case?
+        // cross coverage for contention case 1st cycle with LSU regfile write win
+        cr_waddr_rd_lsu_apu_wb_contention : cross cp_apu_busy, cp_apu_rvalid,
+                                                  cp_lsu_apu_contention_wr_rd,
+                                                  cp_apu_contention {
+            bins main_cr_bin = cr_waddr_rd_lsu_apu_wb_contention
+                               with ( (cp_apu_rvalid == 1) & (fpu_latency == 1) );
+
+            `IGNORE_BINS_NO_CONTENTION_LSU
+        }
+
+    endgroup : cg_f_inst_reg
+
+endclass : uvme_cv32e40p_fp_instr_covg
+
+function uvme_cv32e40p_fp_instr_covg::new(string name = "cv32e40p_fp_instr_covg", uvm_component parent = null);
+    super.new(name, parent);
+    void'(uvm_config_db#(uvme_cv32e40p_cfg_c)::get(this, "", "cfg", cfg));
+    if (cfg == null) begin
+      `uvm_fatal("cv32e40p_fp_instr_covg", "Configuration handle is null")
+    end
+
+    cg_f_multicycle = new(.fpu_latency(cfg.fpu_latency));
+    cg_f_inst_reg = new(.fpu_latency(cfg.fpu_latency));
+
+endfunction : new
+
+function void uvme_cv32e40p_fp_instr_covg::build_phase(uvm_phase phase);
+    super.build_phase(phase);
+
+    void'(uvm_config_db#(uvme_cv32e40p_cntxt_c)::get(this, "", "cntxt", cntxt));
+    if (cntxt == null) begin
+        `uvm_fatal("cv32e40p_fp_instr_covg", "No cntxt object passed to model");
+    end
+endfunction : build_phase
+
+task uvme_cv32e40p_fp_instr_covg::run_phase(uvm_phase phase);
+    super.run_phase(phase);
+    `uvm_info("cv32e40p_fp_instr_covg", "The RV32_F coverage model is running", UVM_LOW);
+    fork
+        sample_clk_i();
+    join_none
+endtask : run_phase
+
+
+task uvme_cv32e40p_fp_instr_covg::sample_clk_i();
+    while (1) begin
+        @(`COVIF_CB);
+        cg_f_multicycle.sample();
+        cg_f_inst_reg.sample();
+    end
+endtask  : sample_clk_i

--- a/cv32e40p/env/uvme/cov/uvme_cv32e40p_zfinx_instr_covg.sv
+++ b/cv32e40p/env/uvme/cov/uvme_cv32e40p_zfinx_instr_covg.sv
@@ -1,0 +1,772 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright 2023 OpenHW Group
+// Copyright 2023 Dolphin Design
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+//
+///////////////////////////////////////////////////////////////////////////////
+
+class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
+    /*
+    * Class members
+    */
+    uvme_cv32e40p_cfg_c    cfg;
+    uvme_cv32e40p_cntxt_c  cntxt;
+
+    `uvm_component_utils_begin(uvme_cv32e40p_zfinx_instr_covg)
+      `uvm_field_object(cfg  , UVM_DEFAULT)
+      `uvm_field_object(cntxt, UVM_DEFAULT)
+    `uvm_component_utils_end
+
+    extern function new(string name = "cv32e40p_zfinx_instr_covg", uvm_component parent = null);
+    extern function void build_phase(uvm_phase phase);
+    extern task run_phase(uvm_phase phase);
+    extern task sample_clk_i();
+
+    `define FPU_LAT_0_2_EX_REGFILE_ALU_WR_NO_STALL_COND \
+     (cp_is_mulh_ex == 0) & (cp_is_misaligned_data_req_ex == 0) & (cp_is_post_inc_ld_st_inst_ex == 0) & (cp_ex_apu_valid_memorised == 0)
+
+    `define FPU_MULTICYCLE_WINDOW_ILLEGAL_CASES \
+     illegal_bins clk_2_19_group_NON_DIVSQRT  = ( (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1}) ) \
+                                                   with ( (cp_f_multicycle_clk_window != 0) & (fpu_latency == 0) & `FPU_LAT_0_2_EX_REGFILE_ALU_WR_NO_STALL_COND ); \
+     illegal_bins clk_3_19_group_NON_DIVSQRT  = ( (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1, 2}) ) \
+                                                   with ( (cp_f_multicycle_clk_window != 0) & (fpu_latency == 1) & `FPU_LAT_0_2_EX_REGFILE_ALU_WR_NO_STALL_COND ); \
+     illegal_bins clk_4_19_group_NON_DIVSQRT  = ( (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1, 2, 3}) ) \
+                                                   with ( (cp_f_multicycle_clk_window != 0) & (fpu_latency == 2) & `FPU_LAT_0_2_EX_REGFILE_ALU_WR_NO_STALL_COND );
+
+    `define FPU_ZERO_LATENCY_ILLEGAL_BUSY \
+     illegal_bins apu_busy_curr_apu_op_not_div_sqrt = ( !binsof(cp_curr_fpu_apu_op_multicycle) intersect {APU_OP_FDIV, APU_OP_FSQRT} ) \
+                                                      with ( ((cp_curr_fpu_apu_op_multicycle + 1) * (fpu_latency == 0)) != 0 );
+
+    `define IGNORE_BINS_ZERO_LAT_FPU_OP \
+     ignore_bins zero_lat_inst = ( !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT} ) \
+                                 with ( ((cp_curr_fpu_apu_op + 1) * (fpu_latency == 0)) != 0 );
+
+    `define IGNORE_BINS_CONTENTION_IN_LSU_WITH_APU \
+     ignore_bins in_contention_lsu_wr = ( binsof(cp_apu_contention) intersect {1} ) \
+                                        with ( ((cp_curr_fpu_apu_op + 1) * (fpu_latency == 1)) != 0 );
+
+    `define IGNORE_BINS_NON_RS1_CV32E40P_INSTR \
+     ignore_bins non_rs1_rv32_instr = binsof(cp_id_stage_non_rv32fc_inst) intersect {TB_OPCODE_LUI,TB_OPCODE_AUIPC,TB_OPCODE_JAL};
+
+    `define IGNORE_BINS_NON_RS2_CV32E40P_INSTR \
+     ignore_bins non_rs2_rv32_instr = binsof(cp_id_stage_non_rv32fc_inst) intersect {`RV32_INSTR_WITH_NO_RS2};
+
+    `define IGNORE_BINS_NON_STALLED_CONTENTION_WR_STATE \
+     ignore_bins non_stalled_contention_wr_state = binsof(cp_contention_state) intersect {0,1};
+
+    `define IGNORE_BINS_CONTENTION_AT_LSU_REGFILE_WR \
+     ignore_bins contention_at_lsu_wr = binsof(cp_apu_contention) intersect {1};
+
+    `define IGNORE_BINS_NO_CONTENTION \
+     ignore_bins no_contention = binsof(cp_apu_contention) intersect {1};
+
+    `define IGNORE_BINS_NON_RS3_ZFINX_INSTR \
+     ignore_bins non_rs3_f_inst = !binsof(cp_id_stage_f_inst) intersect {`RV32F_INSTR_WITH_NO_FS3};
+
+    `define IGNORE_BINS_NO_CONTENTION_LSU \
+     ignore_bins no_contention_lsu_wr = binsof(cp_apu_contention) intersect {0};
+
+    `define CP_FOR_USE_WITH_WITH_CONSTRUCT_EXCLUDING_SPECIAL_CASES \
+     cp_is_mulh_ex, cp_is_misaligned_data_req_ex, cp_is_post_inc_ld_st_inst_ex, cp_ex_apu_valid_memorised
+
+    /*
+    * Covergroups
+    */
+
+    covergroup cg_f_multicycle(int fpu_latency);
+        `per_instance_fcov
+        option.at_least = 10;
+
+        cp_if_stage_f_inst : coverpoint `COVIF_CB.if_stage_instr_rdata_i iff (`COVIF_CB.if_stage_instr_rvalid_i == 1) {
+            `ZFINX_INSTR_BINS
+            option.weight = 5;
+        }
+
+        cp_id_stage_f_inst : coverpoint `COVIF_CB.id_stage_instr_rdata_i iff (`COVIF_CB.id_stage_instr_valid_i == 1) {
+            `ZFINX_INSTR_BINS
+            option.weight = 5;
+        }
+
+        cp_id_stage_apu_op_ex_o : coverpoint `COVIF_CB.id_stage_apu_op_ex_o iff (`COVIF_CB.id_stage_apu_en_ex_o == 1) {
+            `FPU_OP_BINS
+            option.weight = 5;
+        }
+
+        cp_f_multicycle_clk_window : coverpoint cntxt.cov_vif.if_clk_cycle_window {
+            bins clk1 = {1};
+            bins clk2 = {2};
+            bins clk3 = {3};
+            bins clk4 = {4};
+            bins clk5 = {5};
+            bins clk6 = {6};
+            bins clk7 = {7};
+            bins clk8 = {8};
+            bins clk9 = {9};
+            bins clk10 = {10};
+            bins clk11 = {11};
+            bins clk12 = {12};
+            bins clk13 = {13};
+            bins clk14 = {14};
+            bins clk15 = {15};
+            bins clk16 = {16};
+            bins clk17 = {17};
+            bins clk18 = {18};
+            bins clk19 = {19};
+            ignore_bins ignore_idle = {0};
+            illegal_bins clk_more_than_19 = {[20:31]};
+        }
+
+        cp_id_stage_inst_valid : coverpoint `COVIF_CB.id_stage_instr_valid_i {
+            bins id_stage_instr_valid = {1};
+            option.weight = 1;
+        }
+
+        cp_if_stage_inst_valid : coverpoint `COVIF_CB.if_stage_instr_rvalid_i {
+            bins if_stage_instr_valid = {1};
+            option.weight = 1;
+        }
+
+        cp_id_stage_apu_en_ex_o : coverpoint `COVIF_CB.id_stage_apu_en_ex_o {
+            bins id_stage_apu_en_ex_1 = {1};
+            bins id_stage_apu_en_ex_0_to_1 = (0 => 1);
+            option.weight = 1;
+        }
+
+        cp_apu_req_valid : coverpoint `COVIF_CB.apu_req {
+            bins apu_req_valid = {1'b1};
+            option.weight = 1;
+        }
+
+        cp_apu_grant_valid : coverpoint `COVIF_CB.apu_gnt {
+            bins apu_gnt_valid = {1'b1};
+            option.weight = 1;
+        }
+
+        cp_apu_busy : coverpoint `COVIF_CB.apu_busy {
+            bins apu_busy_high = {1'b1};
+            option.weight = 1;
+        }
+
+        cp_curr_fpu_apu_op : coverpoint cntxt.cov_vif.o_curr_fpu_apu_op_if {
+            `FPU_OP_BINS
+            option.weight = 5;
+        }
+
+        cp_curr_fpu_apu_op_at_apu_req : coverpoint cntxt.cov_vif.o_curr_fpu_apu_op_if iff ( (`COVIF_CB.apu_req == 1) &&
+                                                                                            (`COVIF_CB.apu_gnt == 1) )
+        {
+            `FPU_OP_BINS
+            option.weight = 5;
+        }
+
+        cp_curr_fpu_apu_op_multicycle : coverpoint cntxt.cov_vif.o_curr_fpu_apu_op_if iff (`COVIF_CB.apu_busy == 1)
+        {
+            `FPU_OP_BINS
+            option.weight = 5;
+        }
+
+        cp_is_mulh_ex : coverpoint cntxt.cov_vif.is_mulh_ex {
+            bins not_mulh = {1'b0};
+            option.weight = 1;
+        }
+
+        cp_is_misaligned_data_req_ex : coverpoint cntxt.cov_vif.is_misaligned_data_req_ex {
+            bins not_misaligned_data_req_ex = {1'b0};
+            option.weight = 1;
+        }
+
+        cp_is_post_inc_ld_st_inst_ex : coverpoint cntxt.cov_vif.is_post_inc_ld_st_inst_ex {
+            bins not_post_inc_ld_st_inst_ex = {1'b0};
+            option.weight = 1;
+        }
+
+        cp_ex_apu_valid_memorised : coverpoint cntxt.cov_vif.ex_apu_valid_memorised {
+            bins not_apu_valid_mem = {1'b0};
+            option.weight = 1;
+        }
+
+        // cross coverage for F-inst in ID-stage with preceeding F-multicycle instr
+        cr_f_inst_at_id_stage_inp_with_fpu_multicycle_req : cross cp_id_stage_f_inst,
+                                                                  cp_curr_fpu_apu_op_at_apu_req
+        {option.weight = 50;}
+
+        // cross coverage for F-inst in ID-stage with preceeding F-multicycle
+        // case with apu_busy or APU needing more than 1 clock cycle 
+        cr_f_inst_at_id_stage_inp_while_fpu_busy : cross cp_id_stage_f_inst,
+                                                         cp_curr_fpu_apu_op_multicycle {
+            option.weight = 50;
+            // For FPU config with Latency=0 , apu_busy is expected to be set only for FDIV and FSQRT case
+            `FPU_ZERO_LATENCY_ILLEGAL_BUSY
+        }
+
+        // cross coverage for F-inst arriving at ID-stage input at various stages of APU latency
+        // clk-cycles of the ongoing/preceeding F-multicycle instr
+        cr_f_inst_at_id_stage_inp_with_cyc_window_of_ongoing_fpu_calc : cross cp_id_stage_f_inst,
+                                                                              cp_f_multicycle_clk_window,
+                                                                              cp_curr_fpu_apu_op,
+                                                                              `CP_FOR_USE_WITH_WITH_CONSTRUCT_EXCLUDING_SPECIAL_CASES {
+            option.weight = 50;
+            `FPU_MULTICYCLE_WINDOW_ILLEGAL_CASES
+        }
+
+        // cross coverage for F-inst at ID-stage output with preceeding F-multicycle instr
+        // Note: Added 2 separate similar cross coverages ID stage because of different
+        // arrival times of next instruction w.r.t APU Req
+        cr_f_inst_at_id_stage_out_with_fpu_multicycle_req : cross cp_id_stage_apu_op_ex_o,
+                                                                  cp_curr_fpu_apu_op_at_apu_req
+        {option.weight = 50;}
+
+        // cross coverage for F-inst at ID-stage output with preceeding F-multicycle
+        // case with apu_busy or APU needing more than 1 clock cycle 
+        // Note: Added 2 separate similar cross coverages ID stage because of different
+        // arrival times of next instruction w.r.t APU Req
+        cr_f_inst_at_id_stage_out_while_fpu_busy : cross cp_id_stage_apu_op_ex_o,
+                                                         cp_curr_fpu_apu_op_multicycle {
+            option.weight = 50;
+            `FPU_ZERO_LATENCY_ILLEGAL_BUSY
+        }
+
+        // cross coverage for F-inst arriving at ID-stage output at various stages of APU latency
+        // clk-cycles of the ongoing/preceeding F-multicycle instr
+        // Note: Added 2 separate similar cross coverages ID stage because of different
+        // arrival times of next instruction w.r.t APU Req
+        cr_f_inst_at_id_stage_out_with_cyc_window_of_ongoing_fpu_calc : cross cp_id_stage_apu_op_ex_o,
+                                                                              cp_f_multicycle_clk_window,
+                                                                              cp_curr_fpu_apu_op,
+                                                                              `CP_FOR_USE_WITH_WITH_CONSTRUCT_EXCLUDING_SPECIAL_CASES {
+
+            option.weight = 50;
+            `FPU_MULTICYCLE_WINDOW_ILLEGAL_CASES
+        }
+
+        // cross coverage for F-inst at IF-stage with preceeding F-multicycle instr
+        cr_f_inst_at_if_stage_inp_with_fpu_multicycle_req : cross cp_if_stage_f_inst,
+                                                                  cp_curr_fpu_apu_op_at_apu_req
+        {option.weight = 50;}
+
+        // cross coverage for F-inst at IF-stage with preceeding F-multicycle
+        // case with apu_busy or APU needing more than 1 clock cycle 
+        cr_f_inst_at_if_stage_inp_while_fpu_busy : cross cp_if_stage_f_inst,
+                                                         cp_curr_fpu_apu_op_multicycle {
+            option.weight = 50;
+            `FPU_ZERO_LATENCY_ILLEGAL_BUSY
+        }
+
+        // cross coverage for F-inst arriving at IF-stage output at various stages of
+        // APU latency clk-cycles of the ongoing/preceeding F-multicycle instr
+        cr_f_inst_at_if_stage_inp_with_cyc_window_of_ongoing_fpu_calc : cross cp_if_stage_f_inst,
+                                                                              cp_f_multicycle_clk_window,
+                                                                              cp_curr_fpu_apu_op,
+                                                                              `CP_FOR_USE_WITH_WITH_CONSTRUCT_EXCLUDING_SPECIAL_CASES {
+
+            option.weight = 50;
+            `FPU_MULTICYCLE_WINDOW_ILLEGAL_CASES
+        }
+
+    endgroup : cg_f_multicycle
+
+
+    covergroup cg_zfinx_inst_reg(int fpu_latency);
+        `per_instance_fcov
+
+        cp_apu_req_valid : coverpoint `COVIF_CB.apu_req {
+            bins apu_req_valid = {1'b1};
+            option.weight = 1;
+        }
+
+        cp_apu_grant_valid : coverpoint `COVIF_CB.apu_gnt {
+            bins apu_gnt_valid = {1'b1};
+            option.weight = 1;
+        }
+
+        cp_apu_busy : coverpoint `COVIF_CB.apu_busy {
+            bins apu_busy_high = {1'b1};
+            option.weight = 1;
+        }
+
+        cp_apu_rvalid : coverpoint `COVIF_CB.apu_rvalid_i {
+            bins apu_rvalid = {1};
+            option.weight = 1;
+        }
+
+        cp_apu_contention : coverpoint `COVIF_CB.apu_perf_wb_o {
+            bins no_contention = {0};
+            bins has_contention = {1};
+            option.weight = 1;
+        }
+
+        cp_curr_fpu_apu_op : coverpoint cntxt.cov_vif.o_curr_fpu_apu_op_if {
+            `FPU_OP_BINS
+            option.weight = 5;
+        }
+
+        cp_last_fpu_apu_op_at_contention : coverpoint cntxt.cov_vif.o_last_fpu_apu_op_if {
+            bins curr_apu_op_fmadd        =    {APU_OP_FMADD}       with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fnmsub       =    {APU_OP_FNMSUB}      with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fadd         =    {APU_OP_FADD}        with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fmul         =    {APU_OP_FMUL}        with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fdiv         =    {APU_OP_FDIV}        with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fsqrt        =    {APU_OP_FSQRT}       with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fsgnj        =    {APU_OP_FSGNJ}       with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fminmax      =    {APU_OP_FMINMAX}     with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fcmp         =    {APU_OP_FCMP}        with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fclassify    =    {APU_OP_FCLASSIFY}   with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_f2f          =    {APU_OP_F2F}         with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_f2i          =    {APU_OP_F2I}         with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_i2f          =    {APU_OP_I2F}         with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fmsub        =    {APU_OP_FMSUB}       with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fnmadd       =    {APU_OP_FNMADD}      with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fsub         =    {APU_OP_FSUB}        with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fsgnj_se     =    {APU_OP_FSGNJ_SE}    with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_f2i_u        =    {APU_OP_F2I_U}       with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_i2f_u        =    {APU_OP_I2F_U}       with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            option.weight = 5;
+        }
+
+        // TODO: need to add another cover point for F-inst at ID-EX boundary ?
+        cp_id_stage_f_inst : coverpoint `COVIF_CB.id_stage_instr_rdata_i
+                                        iff (`COVIF_CB.id_stage_instr_valid_i == 1) {
+
+            `ZFINX_INSTR_BINS
+            option.weight = 5;
+        }
+
+        // TODO: to add rv32c coverage
+        cp_id_stage_non_rv32fc_inst : coverpoint `COVIF_CB.id_stage_instr_rdata_i[6:0]
+                                                 iff (`COVIF_CB.id_stage_instr_valid_i == 1) {
+
+            `CV32E40P_INSTR_OPCODE_BIT_6_0_BINS__NO_RV32C_FC
+            option.weight = 5;
+        }
+
+        cp_id_f_inst_fs1 : coverpoint `COVIF_CB.id_stage_instr_rdata_i[19:15]
+                                      iff (`COVIF_CB.id_stage_instr_valid_i == 1) {
+
+            bins fs1[] = {[0:31]};
+            option.weight = 1;
+        }
+        cp_id_f_inst_fs2 : coverpoint `COVIF_CB.id_stage_instr_rdata_i[24:20]
+                                      iff (`COVIF_CB.id_stage_instr_valid_i == 1) {
+
+            bins fs2[] = {[0:31]};
+            option.weight = 1;
+        }
+        cp_curr_fpu_inst_fd : coverpoint cntxt.cov_vif.curr_fpu_fd {
+            bins fd[] = {[0:31]};
+            option.weight = 1;
+        }
+        cp_curr_fpu_inst_rd : coverpoint cntxt.cov_vif.curr_fpu_rd {
+            bins rd[] = {[0:31]};
+            option.weight = 1;
+        }
+        cp_curr_fpu_inst_rd_for_0_lat_apu_result : coverpoint cntxt.cov_vif.curr_fpu_rd
+                                                              iff ( (`COVIF_CB.apu_req == 1) && 
+                                                                    (`COVIF_CB.apu_gnt == 1) &&         
+                                                                    (`COVIF_CB.apu_rvalid_i == 1) ) {
+
+            bins rd[] = {[0:31]};
+            option.weight = 1;
+        }
+        cp_curr_fpu_inst_rd_for_multicyc_lat_apu_result : coverpoint cntxt.cov_vif.curr_fpu_rd
+                                                                     iff ( (`COVIF_CB.apu_busy == 1) && 
+                                                                           (`COVIF_CB.apu_rvalid_i == 1) ) {
+
+            bins rd[] = {[0:31]};
+            option.weight = 1;
+        }
+        cp_id_x_inst_rs1 : coverpoint `COVIF_CB.id_stage_instr_rdata_i[19:15]
+                                      iff (`COVIF_CB.id_stage_instr_valid_i == 1) {
+
+
+            bins rs1[] = {[0:31]};
+            option.weight = 1;
+        }
+
+        cp_apu_alu_contention_wr_rd : coverpoint cntxt.cov_vif.curr_rd_at_ex_regfile_wr_contention {
+            bins rd[] = {[0:31]} with ( (item < 32) & (fpu_latency != 1) );
+            illegal_bins rd_addr_32_63 = {[32:63]};
+            option.weight = 1;
+        }
+        cp_lsu_apu_contention_wr_rd : coverpoint cntxt.cov_vif.curr_rd_at_wb_regfile_wr_contention {
+            bins rd[] = {[0:31]} with ( (item < 32) & (fpu_latency == 1) );
+            illegal_bins rd_addr_32_63 = {[32:63]};
+            option.weight = 1;
+        }
+        cp_prev_rd_waddr_contention : coverpoint cntxt.cov_vif.prev_rd_waddr_contention {
+            bins rd[] = {[0:31]};
+            illegal_bins rd_addr_32_63 = {[32:63]};  //for zfinx only 32 gprs available
+            option.weight = 1;
+        }
+
+        cp_contention_state : coverpoint cntxt.cov_vif.contention_state {
+            bins no_contention = {0};
+            bins contention_1st_cyc_done = {1};
+            bins contention_2nd_cyc_done = {2};
+            ignore_bins state3 = {3};
+            option.weight = 1;
+        }
+
+        cp_b2b_contention : coverpoint cntxt.cov_vif.b2b_contention {
+            bins b2b_contention_true = {1};
+            option.weight = 5;
+        }
+
+        cp_rd_rs1_eq : coverpoint (`COVIF_CB.id_stage_instr_rdata_i[19:15] == cntxt.cov_vif.curr_fpu_rd)
+                                  iff (`COVIF_CB.id_stage_instr_valid_i == 1) {
+
+            bins rd_rs1_equal = {1};
+        }
+        cp_rd_rs2_eq : coverpoint (`COVIF_CB.id_stage_instr_rdata_i[24:20] == cntxt.cov_vif.curr_fpu_rd)
+                                  iff (`COVIF_CB.id_stage_instr_valid_i == 1) {
+
+            bins rd_rs2_equal = {1};
+        }
+        cp_rd_rs3_eq : coverpoint (`COVIF_CB.id_stage_instr_rdata_i[31:27] == cntxt.cov_vif.curr_fpu_rd)
+                                  iff (`COVIF_CB.id_stage_instr_valid_i == 1) {
+
+            bins rd_rs3_equal = {1};
+        }
+        cp_contention_rd_rd_eq : coverpoint (cntxt.cov_vif.curr_rd_at_ex_regfile_wr_contention == cntxt.cov_vif.prev_rd_waddr_contention) {
+            bins contention_rd_rd_equal = {1} with ( (item == 1) & (fpu_latency != 1) );
+        }
+        cp_contention_rd_rd_eq_fpu_lat_1 : coverpoint (cntxt.cov_vif.curr_fpu_rd == cntxt.cov_vif.prev_rd_waddr_contention) {
+            bins contention_rd_rd_equal = {1}  with ( (item == 1) & (fpu_latency == 1) );
+        }
+
+        //*********************************************************************************************************
+        //     Cross Cov description for reg-to-reg dependency cases in instr sequence with F-multicycle instr
+        //*********************************************************************************************************
+        
+        //*********************************************************************************************************
+        // CASES WITH/WITHOUT CONTENTION AT THE TIME OF APU RESULT WRITE TO REGFILE
+        // WHERE APU WRITE WILL WIN (APU LATENCY = 0,2,3,4)
+        //*********************************************************************************************************
+
+        // cross coverage for F-instr following F-instr with rd to rs1 dependency
+        // case with APU latency > 0
+        cr_rd_rs1_eq_nonzero_lat  :  cross cp_rd_rs1_eq,
+                                           cp_id_stage_f_inst,
+                                           cp_curr_fpu_inst_rd_for_multicyc_lat_apu_result,
+                                           cp_curr_fpu_apu_op,
+                                           cp_apu_contention {
+
+            option.weight = 50;
+            `IGNORE_BINS_ZERO_LAT_FPU_OP
+            `IGNORE_BINS_CONTENTION_IN_LSU_WITH_APU
+        }
+
+        // cross coverage for F-instr following F-instr with rd to rs2 dependency
+        // case with APU latency > 0
+        cr_rd_rs2_eq_nonzero_lat  :  cross cp_rd_rs2_eq,
+                                           cp_id_stage_f_inst,
+                                           cp_curr_fpu_inst_rd_for_multicyc_lat_apu_result,
+                                           cp_curr_fpu_apu_op,
+                                           cp_apu_contention {
+
+            option.weight = 50;
+            `IGNORE_BINS_ZERO_LAT_FPU_OP
+            `IGNORE_BINS_CONTENTION_IN_LSU_WITH_APU
+        }
+
+        // cross coverage for F-instr following F-instr with rd to rs3 dependency
+        // case with APU latency > 0
+        cr_rd_rs3_eq_nonzero_lat  :  cross cp_rd_rs3_eq,
+                                           cp_id_stage_f_inst,
+                                           cp_curr_fpu_inst_rd_for_multicyc_lat_apu_result,
+                                           cp_curr_fpu_apu_op,
+                                           cp_apu_contention {
+
+            option.weight = 50;
+            `IGNORE_BINS_ZERO_LAT_FPU_OP
+            `IGNORE_BINS_CONTENTION_IN_LSU_WITH_APU
+            `IGNORE_BINS_NON_RS3_ZFINX_INSTR
+        }
+
+        // cross coverage for Non F-instr following F-instr with rd to rs1 dependency
+        // case with APU latency > 0
+        cr_rv32f_rd_non_rv32f_rs1_eq_nonzero_lat : cross cp_rd_rs1_eq,
+                                                         cp_id_stage_non_rv32fc_inst,
+                                                         cp_curr_fpu_inst_rd_for_multicyc_lat_apu_result,
+                                                         cp_curr_fpu_apu_op,
+                                                         cp_apu_contention {
+
+            option.weight = 50;
+            `IGNORE_BINS_ZERO_LAT_FPU_OP
+            `IGNORE_BINS_CONTENTION_IN_LSU_WITH_APU
+            `IGNORE_BINS_NON_RS1_CV32E40P_INSTR
+        }
+
+        // cross coverage for Non F-instr following F-instr with rd to rs2 dependency
+        // case with APU latency > 0
+        cr_rv32f_rd_non_rv32f_rs2_eq_nonzero_lat : cross cp_rd_rs2_eq,
+                                                         cp_id_stage_non_rv32fc_inst,
+                                                         cp_curr_fpu_inst_rd_for_multicyc_lat_apu_result,
+                                                         cp_curr_fpu_apu_op,
+                                                         cp_apu_contention {
+
+            option.weight = 50;
+            `IGNORE_BINS_ZERO_LAT_FPU_OP
+            `IGNORE_BINS_CONTENTION_IN_LSU_WITH_APU
+            `IGNORE_BINS_NON_RS1_CV32E40P_INSTR
+            `IGNORE_BINS_NON_RS2_CV32E40P_INSTR
+        }
+
+        // cross coverage for contention case 2nd cycle with ALU regfile write
+        cr_waddr_rd_apu_alu_ex_contention : cross cp_apu_alu_contention_wr_rd,
+                                                  cp_contention_state,
+                                                  cp_apu_contention {
+
+            bins main_cr_bin = cr_waddr_rd_apu_alu_ex_contention
+                               with ( (cp_contention_state <= 3) & (fpu_latency != 1) );
+
+            `IGNORE_BINS_NON_STALLED_CONTENTION_WR_STATE
+            `IGNORE_BINS_NO_CONTENTION
+        }
+
+        // cross coverage for RD-RD equal for both contention instructions
+        cr_contention_rd_rd_eq : cross cp_contention_rd_rd_eq,
+                                       cp_contention_state,
+                                       cp_apu_contention {
+
+            bins main_cr_bin = cr_contention_rd_rd_eq
+                               with ( (cp_contention_state <= 3) & (fpu_latency != 1) );
+
+            `IGNORE_BINS_NON_STALLED_CONTENTION_WR_STATE
+            `IGNORE_BINS_NO_CONTENTION
+        }
+
+        // cross coverage for RD-RD equal for both contention instructions for
+        // fpu_laterncy=1
+        cr_contention_rd_rd_eq_fpu_lat_1 : cross cp_contention_rd_rd_eq_fpu_lat_1,
+                                                 cp_contention_state,
+                                                 cp_apu_contention {
+
+            bins main_cr_bin = cr_contention_rd_rd_eq_fpu_lat_1
+                               with ( (cp_contention_state <= 3) & (fpu_latency == 1) );
+
+            `IGNORE_BINS_NON_STALLED_CONTENTION_WR_STATE
+            `IGNORE_BINS_NO_CONTENTION
+        }
+
+        //*********************************************************************************************************
+        // CASES WITH/WITHOUT CONTENTION AT APU RESULT WRITE TO REGFILE. APU_LATENCY=0 PRIOIRTY APU WRITE WINS
+        //*********************************************************************************************************
+
+        // cross coverage for F-instr following F-instr with rd to rs1 dependency - 0 Latency
+        cr_rd_rs1_eq_no_lat  :  cross cp_rd_rs1_eq,
+                                      cp_id_stage_f_inst,
+                                      cp_curr_fpu_inst_rd_for_0_lat_apu_result,
+                                      cp_curr_fpu_apu_op,
+                                      cp_apu_contention {
+
+            option.weight = 50;
+            bins main_cr_bin =  cr_rd_rs1_eq_no_lat with ( (cp_rd_rs1_eq == 1) & (fpu_latency == 0) );
+        }
+
+        // cross coverage for F-instr following F-instr with rd to rs2 dependency - 0 Latency
+        cr_rd_rs2_eq_no_lat  :  cross cp_rd_rs2_eq,
+                                      cp_id_stage_f_inst,
+                                      cp_curr_fpu_inst_rd_for_0_lat_apu_result,
+                                      cp_curr_fpu_apu_op,
+                                      cp_apu_contention {
+
+            option.weight = 50;
+            bins main_cr_bin =  cr_rd_rs2_eq_no_lat with ( (cp_rd_rs2_eq == 1) & (fpu_latency == 0) );
+        }
+        
+        // cross coverage for F-instr following F-instr with rd to rs3 dependency - 0 Latency
+        cr_rd_rs3_eq_no_lat  :  cross cp_rd_rs3_eq,
+                                      cp_id_stage_f_inst,
+                                      cp_curr_fpu_inst_rd_for_0_lat_apu_result,
+                                      cp_curr_fpu_apu_op,
+                                      cp_apu_contention {
+
+            option.weight = 50;
+            bins main_cr_bin =  cr_rd_rs3_eq_no_lat with ( (cp_rd_rs3_eq == 1) & (fpu_latency == 0) );
+
+            `IGNORE_BINS_NON_RS3_ZFINX_INSTR
+        }
+
+        // cross coverage for Non F-instr following F-instr with rd to rs1 dependency - 0 Latency
+        cr_rv32f_rd_non_rv32fc_rs1_eq_no_lat  :  cross cp_rd_rs1_eq,
+                                                       cp_id_stage_non_rv32fc_inst,
+                                                       cp_curr_fpu_inst_rd_for_0_lat_apu_result,
+                                                       cp_curr_fpu_apu_op,
+                                                       cp_apu_contention {
+
+            option.weight = 50;
+            bins main_cr_bin =  cr_rv32f_rd_non_rv32fc_rs1_eq_no_lat
+                                with ( (cp_rd_rs1_eq == 1) & (fpu_latency == 0) );
+
+            `IGNORE_BINS_NON_RS1_CV32E40P_INSTR
+        }
+        // cross coverage for Non F-instr following F-instr with rd to rs2 dependency - 0 Latency
+        cr_rv32f_rd_non_rv32fc_rs2_eq_no_lat  :  cross cp_rd_rs2_eq,
+                                                       cp_id_stage_non_rv32fc_inst,
+                                                       cp_curr_fpu_inst_rd_for_0_lat_apu_result,
+                                                       cp_curr_fpu_apu_op,
+                                                       cp_apu_contention {
+
+            option.weight = 50;
+            bins main_cr_bin =  cr_rv32f_rd_non_rv32fc_rs2_eq_no_lat
+                                with ( (cp_rd_rs2_eq == 1) & (fpu_latency == 0) );
+
+            `IGNORE_BINS_NON_RS2_CV32E40P_INSTR
+        }
+
+        //*********************************************************************************************************
+        // CONTENTION DURING APU RESULT WRITE TO REGFILE WHERE APU RESULT WRITE STALLS. APU LATENCY = 1
+        //*********************************************************************************************************
+
+        // cross coverage for F-instr following F-instr with rd to rs1 dependency
+        // case with APU latency = 1 and contention with LSU
+        cr_rd_rs1_eq_nonzero_lat_with_contention : cross cp_rd_rs1_eq,
+                                                         cp_id_stage_f_inst,
+                                                         cp_curr_fpu_inst_rd,
+                                                         cp_last_fpu_apu_op_at_contention,
+                                                         cp_contention_state,
+                                                         cp_apu_contention {
+
+            option.weight = 50;
+            bins main_cr_bin = cr_rd_rs1_eq_nonzero_lat_with_contention
+                               with ( (cp_rd_rs1_eq == 1) & (fpu_latency == 1) );
+
+            `IGNORE_BINS_NON_STALLED_CONTENTION_WR_STATE
+            `IGNORE_BINS_CONTENTION_AT_LSU_REGFILE_WR
+        }
+
+        // cross coverage for F-instr following F-instr with rd to rs2 dependency
+        // case with APU latency = 1 and contention with LSU
+        cr_rd_rs2_eq_nonzero_lat_with_contention : cross cp_rd_rs2_eq,
+                                                         cp_id_stage_f_inst,
+                                                         cp_curr_fpu_inst_rd,
+                                                         cp_last_fpu_apu_op_at_contention,
+                                                         cp_contention_state,
+                                                         cp_apu_contention {
+
+            option.weight = 50;
+            bins main_cr_bin = cr_rd_rs2_eq_nonzero_lat_with_contention
+                               with ( (cp_rd_rs2_eq == 1) & (fpu_latency == 1) );
+
+            `IGNORE_BINS_NON_STALLED_CONTENTION_WR_STATE
+            `IGNORE_BINS_CONTENTION_AT_LSU_REGFILE_WR
+        }
+
+        // cross coverage for F-instr following F-instr with rd to rs3 dependency
+        // case with APU latency = 1 and contention with LSU
+        cr_rd_rs3_eq_nonzero_lat_with_contention : cross cp_rd_rs3_eq,
+                                                         cp_id_stage_f_inst,
+                                                         cp_curr_fpu_inst_rd,
+                                                         cp_last_fpu_apu_op_at_contention,
+                                                         cp_contention_state,
+                                                         cp_apu_contention {
+
+            option.weight = 50;
+            bins main_cr_bin = cr_rd_rs3_eq_nonzero_lat_with_contention
+                               with ( (cp_rd_rs3_eq == 1) & (fpu_latency == 1) );
+
+            `IGNORE_BINS_NON_STALLED_CONTENTION_WR_STATE
+            `IGNORE_BINS_CONTENTION_AT_LSU_REGFILE_WR
+        }
+
+        // cross coverage for Non F-instr following F-instr with rd to rs1 dependency
+        // case with APU latency = 1 and contention with LSU
+        cr_rv32f_rd_non_rv32fc_rs1_eq_nonzero_lat_with_contention : cross cp_rd_rs1_eq,
+                                                                          cp_id_stage_non_rv32fc_inst,
+                                                                          cp_curr_fpu_inst_rd,
+                                                                          cp_last_fpu_apu_op_at_contention,
+                                                                          cp_contention_state,
+                                                                          cp_apu_contention {
+
+            option.weight = 50;
+            bins main_cr_bin = cr_rv32f_rd_non_rv32fc_rs1_eq_nonzero_lat_with_contention
+                               with ( (cp_rd_rs1_eq == 1) & (fpu_latency == 1) );
+
+            `IGNORE_BINS_NON_RS1_CV32E40P_INSTR
+            `IGNORE_BINS_NON_STALLED_CONTENTION_WR_STATE
+            `IGNORE_BINS_CONTENTION_AT_LSU_REGFILE_WR
+        }
+
+        // cross coverage for Non F-instr following F-instr with rd to rs2 dependency
+        // case with APU latency = 1 and contention with LSU
+        cr_rv32f_rd_non_rv32fc_rs2_eq_nonzero_lat_with_contention : cross cp_rd_rs2_eq,
+                                                                          cp_id_stage_non_rv32fc_inst,
+                                                                          cp_curr_fpu_inst_rd,
+                                                                          cp_last_fpu_apu_op_at_contention,
+                                                                          cp_contention_state,
+                                                                          cp_apu_contention {
+
+            option.weight = 50;
+            bins main_cr_bin = cr_rv32f_rd_non_rv32fc_rs2_eq_nonzero_lat_with_contention
+                               with ( (cp_rd_rs2_eq == 1) & (fpu_latency == 1) );
+
+            `IGNORE_BINS_NON_RS2_CV32E40P_INSTR
+            `IGNORE_BINS_NON_STALLED_CONTENTION_WR_STATE
+            `IGNORE_BINS_CONTENTION_AT_LSU_REGFILE_WR
+        }
+
+        // TODO: does it require checking rd to rs1/rs2 equal in this case?
+        // cross coverage for contention case 1st cycle with LSU regfile write win
+        cr_waddr_rd_lsu_apu_wb_contention : cross cp_apu_busy,
+                                                  cp_apu_rvalid,
+                                                  cp_lsu_apu_contention_wr_rd,
+                                                  cp_apu_contention {
+
+            bins main_cr_bin = cr_waddr_rd_lsu_apu_wb_contention
+                               with ( (cp_apu_rvalid == 1) & (fpu_latency == 1) );
+
+            `IGNORE_BINS_NO_CONTENTION_LSU
+        }
+    endgroup : cg_zfinx_inst_reg
+
+endclass : uvme_cv32e40p_zfinx_instr_covg
+
+function uvme_cv32e40p_zfinx_instr_covg::new(string name = "cv32e40p_zfinx_instr_covg", uvm_component parent = null);
+    super.new(name, parent);
+    void'(uvm_config_db#(uvme_cv32e40p_cfg_c)::get(this, "", "cfg", cfg));
+    if (cfg == null) begin
+      `uvm_fatal("cv32e40p_zfinx_instr_covg", "Configuration handle is null")
+    end
+
+    cg_f_multicycle = new(.fpu_latency(cfg.fpu_latency));
+    cg_zfinx_inst_reg = new(.fpu_latency(cfg.fpu_latency));
+
+endfunction : new
+
+function void uvme_cv32e40p_zfinx_instr_covg::build_phase(uvm_phase phase);
+    super.build_phase(phase);
+
+    void'(uvm_config_db#(uvme_cv32e40p_cntxt_c)::get(this, "", "cntxt", cntxt));
+    if (cntxt == null) begin
+        `uvm_fatal("cv32e40p_zfinx_instr_covg", "No cntxt object passed to model");
+    end
+endfunction : build_phase
+
+task uvme_cv32e40p_zfinx_instr_covg::run_phase(uvm_phase phase);
+    super.run_phase(phase);
+    `uvm_info("cv32e40p_zfinx_instr_covg", "The RV32ZFINX coverage model is running", UVM_LOW);
+    fork
+        sample_clk_i();
+    join_none
+endtask : run_phase
+
+task uvme_cv32e40p_zfinx_instr_covg::sample_clk_i();
+    while (1) begin
+        @(`COVIF_CB);
+        cg_f_multicycle.sample();
+        cg_zfinx_inst_reg.sample();
+    end
+endtask  : sample_clk_i

--- a/cv32e40p/env/uvme/uvme_cv32e40p_cntxt.sv
+++ b/cv32e40p/env/uvme/uvme_cv32e40p_cntxt.sv
@@ -30,6 +30,7 @@ class uvme_cv32e40p_cntxt_c extends uvm_object;
    virtual uvmt_cv32e40p_vp_status_if         vp_status_vif; ///< Virtual interface for Virtual Peripherals
    virtual uvma_interrupt_if                  intr_vif     ; ///< Virtual interface for interrupts
    virtual uvma_debug_if                      debug_vif    ; ///< Virtual interface for debug
+   virtual uvmt_cv32e40p_cov_if               cov_vif      ; ///< Virtual interface for custom coverage
 
    // Agent context handles
    uvma_cv32e40p_core_cntrl_cntxt_c  core_cntrl_cntxt;

--- a/cv32e40p/env/uvme/uvme_cv32e40p_constants.sv
+++ b/cv32e40p/env/uvme/uvme_cv32e40p_constants.sv
@@ -55,6 +55,55 @@ parameter CV_VP_OBI_SLV_RESP_BASE      = CV_VP_REGISTER_BASE + CV_VP_OBI_SLV_RES
 parameter CV_VP_SIG_WRITER_BASE        = CV_VP_REGISTER_BASE + CV_VP_SIG_WRITER_OFFSET;
 parameter CV_VP_FENCEI_TAMPER_BASE     = CV_VP_REGISTER_BASE + CV_VP_FENCEI_TAMPER_OFFSET;
 
+parameter TB_OPCODE_SYSTEM             =    7'h73;
+parameter TB_OPCODE_FENCE              =    7'h0f;
+parameter TB_OPCODE_OP                 =    7'h33;
+parameter TB_OPCODE_OPIMM              =    7'h13;
+parameter TB_OPCODE_STORE              =    7'h23;
+parameter TB_OPCODE_LOAD               =    7'h03;
+parameter TB_OPCODE_BRANCH             =    7'h63;
+parameter TB_OPCODE_JALR               =    7'h67;
+parameter TB_OPCODE_JAL                =    7'h6f;
+parameter TB_OPCODE_AUIPC              =    7'h17;
+parameter TB_OPCODE_LUI                =    7'h37;
+parameter TB_OPCODE_AMO                =    7'h2F;
+
+parameter TB_OPCODE_OP_FP              =    7'h53;
+parameter TB_OPCODE_OP_FMADD           =    7'h43;
+parameter TB_OPCODE_OP_FNMADD          =    7'h4f;
+parameter TB_OPCODE_OP_FMSUB           =    7'h47;
+parameter TB_OPCODE_OP_FNMSUB          =    7'h4b;
+parameter TB_OPCODE_STORE_FP           =    7'h27;
+parameter TB_OPCODE_LOAD_FP            =    7'h07;
+
+parameter TB_INS_FMADD               =    {5'b?, 2'b00, 10'b?, 3'b?, 5'b?, TB_OPCODE_OP_FMADD};
+parameter TB_INS_FMSUB               =    {5'b?, 2'b00, 10'b?, 3'b?, 5'b?, TB_OPCODE_OP_FMSUB};
+parameter TB_INS_FNMSUB              =    {5'b?, 2'b00, 10'b?, 3'b?, 5'b?, TB_OPCODE_OP_FNMSUB};
+parameter TB_INS_FNMADD              =    {5'b?, 2'b00, 10'b?, 3'b?, 5'b?, TB_OPCODE_OP_FNMADD};
+parameter TB_INS_FADD                =    {5'b00000, 2'b00, 10'b?, 3'b?, 5'b?, TB_OPCODE_OP_FP};
+parameter TB_INS_FSUB                =    {5'b00001, 2'b00, 10'b?, 3'b?, 5'b?, TB_OPCODE_OP_FP};
+parameter TB_INS_FMUL                =    {5'b00010, 2'b00, 10'b?, 3'b?, 5'b?, TB_OPCODE_OP_FP};
+parameter TB_INS_FDIV                =    {5'b00011, 2'b00, 10'b?, 3'b?, 5'b?, TB_OPCODE_OP_FP};
+parameter TB_INS_FSQRT               =    {5'b01011, 2'b00, 5'b0, 5'b?, 3'b?, 5'b?, TB_OPCODE_OP_FP};
+parameter TB_INS_FSGNJS              =    {5'b00100, 2'b00, 10'b?, 3'b000, 5'b?, TB_OPCODE_OP_FP};
+parameter TB_INS_FSGNJNS             =    {5'b00100, 2'b00, 10'b?, 3'b001, 5'b?, TB_OPCODE_OP_FP};
+parameter TB_INS_FSGNJXS             =    {5'b00100, 2'b00, 10'b?, 3'b010, 5'b?, TB_OPCODE_OP_FP};
+parameter TB_INS_FMIN                =    {5'b00101, 2'b00, 10'b?, 3'b000, 5'b?, TB_OPCODE_OP_FP};
+parameter TB_INS_FMAX                =    {5'b00101, 2'b00, 10'b?, 3'b001, 5'b?, TB_OPCODE_OP_FP};
+parameter TB_INS_FCVTWS              =    {5'b11000, 2'b00, 5'b0, 5'b?, 3'b?, 5'b?, TB_OPCODE_OP_FP};
+parameter TB_INS_FCVTWUS             =    {5'b11000, 2'b00, 5'b1, 5'b?, 3'b?, 5'b?, TB_OPCODE_OP_FP};
+parameter TB_INS_FMVXS               =    {5'b11100, 2'b00, 5'b0, 5'b?, 3'b000, 5'b?, TB_OPCODE_OP_FP};
+parameter TB_INS_FEQS                =    {5'b10100, 2'b00, 10'b?, 3'b010, 5'b?, TB_OPCODE_OP_FP};
+parameter TB_INS_FLTS                =    {5'b10100, 2'b00, 10'b?, 3'b001, 5'b?, TB_OPCODE_OP_FP};
+parameter TB_INS_FLES                =    {5'b10100, 2'b00, 10'b?, 3'b000, 5'b?, TB_OPCODE_OP_FP};
+parameter TB_INS_FCLASS              =    {5'b11100, 2'b00, 5'b0, 5'b?, 3'b001, 5'b?, TB_OPCODE_OP_FP};
+parameter TB_INS_FCVTSW              =    {5'b11010, 2'b00, 5'b0, 5'b?, 3'b?, 5'b?, TB_OPCODE_OP_FP};
+parameter TB_INS_FCVTSWU             =    {5'b11010, 2'b00, 5'b1, 5'b?, 3'b?, 5'b?, TB_OPCODE_OP_FP};
+parameter TB_INS_FMVSX               =    {5'b11110, 2'b00, 5'b0, 5'b?, 3'b000, 5'b?, TB_OPCODE_OP_FP};
+parameter TB_INS_FLW                 =    {12'b?,5'b?,3'b010,5'b?,TB_OPCODE_LOAD_FP};
+parameter TB_INS_FSW                 =    {7'b?,5'b?,5'b?,3'b010,5'b?,TB_OPCODE_STORE_FP};
+
+
 //XPULP instructions custom opcodes
 parameter OPCODE_CUSTOM_0 = 7'h0b;
 parameter OPCODE_CUSTOM_1 = 7'h2b;
@@ -442,5 +491,64 @@ parameter INSTR_CV_ADD_DIV8         =    {5'b01101, 1'b1, 1'b0, 5'b?, 5'b?, 3'b1
 parameter INSTR_CV_SUB_DIV2         =    {5'b01110, 1'b1, 1'b0, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_CUSTOM_3};
 parameter INSTR_CV_SUB_DIV4         =    {5'b01110, 1'b1, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
 parameter INSTR_CV_SUB_DIV8         =    {5'b01110, 1'b1, 1'b0, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+
+parameter APU_OP_FMADD              =    {6'h00};
+parameter APU_OP_FNMSUB             =    {6'h01};
+parameter APU_OP_FADD               =    {6'h02};
+parameter APU_OP_FMUL               =    {6'h03};
+parameter APU_OP_FDIV               =    {6'h04};
+parameter APU_OP_FSQRT              =    {6'h05};
+parameter APU_OP_FSGNJ              =    {6'h06};
+parameter APU_OP_FMINMAX            =    {6'h07};
+parameter APU_OP_FCMP               =    {6'h08};
+parameter APU_OP_FCLASSIFY          =    {6'h09};
+parameter APU_OP_F2F                =    {6'h0A};
+parameter APU_OP_F2I                =    {6'h0B};
+parameter APU_OP_I2F                =    {6'h0C};
+
+parameter APU_OP_FMSUB              =    {6'h10};
+parameter APU_OP_FNMADD             =    {6'h11};
+parameter APU_OP_FSUB               =    {6'h12};
+parameter APU_OP_FSGNJ_SE           =    {6'h16};
+parameter APU_OP_F2I_U              =    {6'h1B};
+parameter APU_OP_I2F_U              =    {6'h1C};
+
+//Additional defines based on DUT config parameters
+`ifdef PULP //PULP = 1
+  `ifndef FPU //FPU = 0
+    `define CV32E40P_ISA_DV { RV32I, RV32M, RV32C, RV32X }
+  `else //FPU = 1
+    `ifndef ZFINX
+      `define CV32E40P_ISA_DV { RV32I, RV32M, RV32C, RV32X, RV32F, RV32FC }
+    `else
+      `define CV32E40P_ISA_DV { RV32I, RV32M, RV32C, RV32X, RV32ZFINX }
+    `endif
+  `endif
+`else //PULP = 0, FPU = 1
+  `ifdef FPU
+    `ifndef ZFINX
+      `define CV32E40P_ISA_DV { RV32I, RV32M, RV32C, RV32F, RV32FC }
+    `else
+      `define CV32E40P_ISA_DV { RV32I, RV32M, RV32C, RV32ZFINX }
+    `endif
+  `endif
+`endif
+
+//Base default ISA for tests if nothing else is defined
+`ifndef CV32E40P_ISA_DV
+    `define CV32E40P_ISA_DV { RV32I, RV32M, RV32C }
+`endif
+
+`ifdef FPU_ADDMUL_LAT
+    parameter FPU_ADDMUL_LAT_DV = `FPU_ADDMUL_LAT;
+`else
+    parameter FPU_ADDMUL_LAT_DV = 0;
+`endif
+
+`ifdef FPU_OTHERS_LAT
+    parameter FPU_OTHERS_LAT_DV = `FPU_OTHERS_LAT;
+`else
+    parameter FPU_OTHERS_LAT_DV = 0;
+`endif
 
 `endif // __UVME_CV32E40P_CONSTANTS_SV__

--- a/cv32e40p/env/uvme/uvme_cv32e40p_env.sv
+++ b/cv32e40p/env/uvme/uvme_cv32e40p_env.sv
@@ -377,6 +377,11 @@ function void uvme_cv32e40p_env_c::retrieve_vifs();
       `uvm_fatal("UVME_CV32E40P_ENV", $sformatf("No uvmt_cv32e40p_debug_cov_assert_if found in config database"))
    end
 
+   void'(uvm_config_db#(virtual uvmt_cv32e40p_cov_if)::get(this, "", "cov_vif", cntxt.cov_vif));
+   if (cntxt.cov_vif == null) begin
+      `uvm_fatal("UVME_CV32E40P_ENV", $sformatf("No uvmt_cv32e40p_cov_if found in config database"))
+   end
+
 endfunction: retrieve_vifs
 
 

--- a/cv32e40p/env/uvme/uvme_cv32e40p_macros.sv
+++ b/cv32e40p/env/uvme/uvme_cv32e40p_macros.sv
@@ -22,5 +22,115 @@
 
 `define UVME_CV32E40P_MEM_SIZE 22
 
+`define COVIF_CB cntxt.cov_vif.mon_cb
+
+`define APU_INSTR_WITH_NO_FD \
+ APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U
+
+`define RV32F_INSTR_WITH_NO_FS3 \
+ TB_INS_FMADD,TB_INS_FMSUB,TB_INS_FNMSUB,TB_INS_FNMADD
+
+`define RV32_INSTR_WITH_NO_RS2 \
+ TB_OPCODE_LUI,TB_OPCODE_AUIPC,TB_OPCODE_JAL,TB_OPCODE_JALR,TB_OPCODE_LOAD,TB_OPCODE_OPIMM,TB_OPCODE_FENCE,TB_OPCODE_SYSTEM
+
+`define RV32F_INSTR_BINS \
+ wildcard bins fadd       =    {TB_INS_FADD}; \
+ wildcard bins fsub       =    {TB_INS_FSUB}; \
+ wildcard bins fmul       =    {TB_INS_FMUL}; \
+ wildcard bins fdiv       =    {TB_INS_FDIV}; \
+ wildcard bins fsqrt      =    {TB_INS_FSQRT}; \
+ wildcard bins fsgnjs     =    {TB_INS_FSGNJS}; \
+ wildcard bins fsgnjns    =    {TB_INS_FSGNJNS}; \
+ wildcard bins fsgnjxs    =    {TB_INS_FSGNJXS}; \
+ wildcard bins fmin       =    {TB_INS_FMIN}; \
+ wildcard bins fmax       =    {TB_INS_FMAX}; \
+ wildcard bins fcvtws     =    {TB_INS_FCVTWS}; \
+ wildcard bins fcvtwus    =    {TB_INS_FCVTWUS}; \
+ wildcard bins fmvxs      =    {TB_INS_FMVXS}; \
+ wildcard bins feqs       =    {TB_INS_FEQS}; \
+ wildcard bins flts       =    {TB_INS_FLTS}; \
+ wildcard bins fles       =    {TB_INS_FLES}; \
+ wildcard bins fclass     =    {TB_INS_FCLASS}; \
+ wildcard bins fcvtsw     =    {TB_INS_FCVTSW}; \
+ wildcard bins fcvtswu    =    {TB_INS_FCVTSWU}; \
+ wildcard bins fmvsw      =    {TB_INS_FMVSX}; \
+ wildcard bins fmadd      =    {TB_INS_FMADD}; \
+ wildcard bins fmsub      =    {TB_INS_FMSUB}; \
+ wildcard bins fnmsub     =    {TB_INS_FNMSUB}; \
+ wildcard bins fnmadd     =    {TB_INS_FNMADD}; \
+ wildcard bins flw        =    {TB_INS_FLW}; \
+ wildcard bins fsw        =    {TB_INS_FSW};
+
+`define ZFINX_INSTR_BINS \
+ wildcard bins fadd       =    {TB_INS_FADD}; \
+ wildcard bins fsub       =    {TB_INS_FSUB}; \
+ wildcard bins fmul       =    {TB_INS_FMUL}; \
+ wildcard bins fdiv       =    {TB_INS_FDIV}; \
+ wildcard bins fsqrt      =    {TB_INS_FSQRT}; \
+ wildcard bins fsgnjs     =    {TB_INS_FSGNJS}; \
+ wildcard bins fsgnjns    =    {TB_INS_FSGNJNS}; \
+ wildcard bins fsgnjxs    =    {TB_INS_FSGNJXS}; \
+ wildcard bins fmin       =    {TB_INS_FMIN}; \
+ wildcard bins fmax       =    {TB_INS_FMAX}; \
+ wildcard bins fcvtws     =    {TB_INS_FCVTWS}; \
+ wildcard bins fcvtwus    =    {TB_INS_FCVTWUS}; \
+ wildcard bins fmvxs      =    {TB_INS_FMVXS}; \
+ wildcard bins feqs       =    {TB_INS_FEQS}; \
+ wildcard bins flts       =    {TB_INS_FLTS}; \
+ wildcard bins fles       =    {TB_INS_FLES}; \
+ wildcard bins fclass     =    {TB_INS_FCLASS}; \
+ wildcard bins fcvtsw     =    {TB_INS_FCVTSW}; \
+ wildcard bins fcvtswu    =    {TB_INS_FCVTSWU}; \
+ wildcard bins fmvsw      =    {TB_INS_FMVSX}; \
+ wildcard bins fmadd      =    {TB_INS_FMADD}; \
+ wildcard bins fmsub      =    {TB_INS_FMSUB}; \
+ wildcard bins fnmsub     =    {TB_INS_FNMSUB}; \
+ wildcard bins fnmadd     =    {TB_INS_FNMADD};
+
+`define FPU_OP_BINS \
+ bins apu_op_fmadd      =    {APU_OP_FMADD}; \
+ bins apu_op_fnmsub     =    {APU_OP_FNMSUB}; \
+ bins apu_op_fadd       =    {APU_OP_FADD}; \
+ bins apu_op_fmul       =    {APU_OP_FMUL}; \
+ bins apu_op_fdiv       =    {APU_OP_FDIV}; \
+ bins apu_op_fsqrt      =    {APU_OP_FSQRT}; \
+ bins apu_op_fsgnj      =    {APU_OP_FSGNJ}; \
+ bins apu_op_fminmax    =    {APU_OP_FMINMAX}; \
+ bins apu_op_fcmp       =    {APU_OP_FCMP}; \
+ bins apu_op_fclassify  =    {APU_OP_FCLASSIFY}; \
+ bins apu_op_f2f        =    {APU_OP_F2F}; \
+ bins apu_op_f2i        =    {APU_OP_F2I}; \
+ bins apu_op_i2f        =    {APU_OP_I2F}; \
+ bins apu_op_fmsub      =    {APU_OP_FMSUB}; \
+ bins apu_op_fnmadd     =    {APU_OP_FNMADD}; \
+ bins apu_op_fsub       =    {APU_OP_FSUB}; \
+ bins apu_op_fsgnj_se   =    {APU_OP_FSGNJ_SE}; \
+ bins apu_op_f2i_u      =    {APU_OP_F2I_U}; \
+ bins apu_op_i2f_u      =    {APU_OP_I2F_U};
+
+`define CV32E40P_INSTR_OPCODE_BIT_6_0_BINS__NO_RV32C_FC \
+ bins system_opcode          =    {TB_OPCODE_SYSTEM}; \
+ bins fence_opcode           =    {TB_OPCODE_FENCE}; \
+ bins op_opcode              =    {TB_OPCODE_OP}; \
+ bins opimm_opcode           =    {TB_OPCODE_OPIMM}; \
+ bins store_opcode           =    {TB_OPCODE_STORE}; \
+ bins load_opcode            =    {TB_OPCODE_LOAD}; \
+ bins branch_opcode          =    {TB_OPCODE_BRANCH}; \
+ bins jalr_opcode            =    {TB_OPCODE_JALR}; \
+ bins jal_opcode             =    {TB_OPCODE_JAL}; \
+ bins auipc_opcode           =    {TB_OPCODE_AUIPC}; \
+ bins lui_opcode             =    {TB_OPCODE_LUI}; \
+ bins fpu_fp_opcode          =    {TB_OPCODE_OP_FP}; \
+ bins fpu_fmadd_opcode       =    {TB_OPCODE_OP_FMADD}; \
+ bins fpu_fnmadd_opcode      =    {TB_OPCODE_OP_FNMADD}; \
+ bins fpu_fmsub_opcode       =    {TB_OPCODE_OP_FMSUB}; \
+ bins fpu_fnmsub_opcode      =    {TB_OPCODE_OP_FNMSUB}; \
+ bins fpu_str_opcode         =    {TB_OPCODE_STORE_FP}; \
+ bins fpu_ld_opcode          =    {TB_OPCODE_LOAD_FP}; \
+ bins xpulp_custom_0         =    {OPCODE_CUSTOM_0}; \
+ bins xpulp_custom_1         =    {OPCODE_CUSTOM_1}; \
+ bins xpulp_custom_2         =    {OPCODE_CUSTOM_2}; \
+ bins xpulp_custom_3         =    {OPCODE_CUSTOM_3};
+
 
 `endif // __UVME_CV32E40P_MACROS_SV__

--- a/cv32e40p/env/uvme/uvme_cv32e40p_pkg.sv
+++ b/cv32e40p/env/uvme/uvme_cv32e40p_pkg.sv
@@ -27,6 +27,7 @@
 `include "uvma_clknrst_macros.sv"
 `include "uvme_cv32e40p_macros.sv"
 
+
  /**
  * Encapsulates all the types needed for an UVM environment capable of driving/
  * monitoring and verifying the behavior of an CV32E40P design.
@@ -52,6 +53,8 @@ package uvme_cv32e40p_pkg;
    `include "uvme_cv32e40p_constants.sv"
    `include "uvme_cv32e40p_param_all_insn.sv" // fixme: remove this and import package from core-v-cores (e.g cv32e40p_tracer_pkg.sv)
    `include "uvme_cv32e40p_tdefs.sv"
+
+   cv32e40p_isa_ext_t   cv32e40p_core_isa_list[$] = `CV32E40P_ISA_DV; // CV32E40P supported ISAs
 
    // Objects
    `include "uvma_cv32e40p_core_cntrl_cntxt.sv"

--- a/cv32e40p/env/uvme/uvme_cv32e40p_pkg.sv
+++ b/cv32e40p/env/uvme/uvme_cv32e40p_pkg.sv
@@ -88,6 +88,8 @@ package uvme_cv32e40p_pkg;
    `include "uvme_interrupt_covg.sv"
    `include "uvme_debug_covg.sv"
    `include "uvme_rv32isa_covg.sv"
+   `include "uvme_cv32e40p_fp_instr_covg.sv"
+   `include "uvme_cv32e40p_zfinx_instr_covg.sv"
    `include "uvme_cv32e40p_cov_model.sv"
    `include "uvme_cv32e40p_sb.sv"
    `include "uvme_cv32e40p_vsqr.sv"

--- a/cv32e40p/env/uvme/uvme_cv32e40p_tdefs.sv
+++ b/cv32e40p/env/uvme/uvme_cv32e40p_tdefs.sv
@@ -124,17 +124,27 @@ typedef enum {
 } fetch_toggle_t;
 
 typedef enum logic [2:0] {
-  EBREAKM = 1,
-  TRIGGER = 2,
-  HALTREQ = 3,
-  STEP = 4,
-  RESETHALTREQ = 5
+    EBREAKM = 1,
+    TRIGGER = 2,
+    HALTREQ = 3,
+    STEP = 4,
+    RESETHALTREQ = 5
 } dcsr_cause_t;
 
 typedef enum logic [4:0] {
-  CODE_ILLEGAL = 2,
-  CODE_EBREAK  = 3,
-  CODE_ECALL   = 11
+    CODE_ILLEGAL = 2,
+    CODE_EBREAK  = 3,
+    CODE_ECALL   = 11
 } exception_code_t;
+
+typedef enum {
+    RV32I,
+    RV32M,
+    RV32C,
+    RV32F,
+    RV32FC,
+    RV32ZFINX,
+    RV32X
+} cv32e40p_isa_ext_t;
 
 `endif // __UVME_CV32E40P_TDEFS_SV__

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb.sv
@@ -504,6 +504,37 @@ module uvmt_cv32e40p_tb;
     .pending_enabled_irq()
   );
 
+  //Interface for coverage components
+  uvmt_cv32e40p_cov_if cov_if(
+    .clk_i(clknrst_if.clk),
+    .rst_ni(clknrst_if.reset_n),
+    .if_stage_instr_rvalid_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.if_stage_i.instr_rvalid_i),
+    .if_stage_instr_rdata_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.if_stage_i.instr_rdata_i),
+    .id_stage_instr_valid_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.instr_valid_i),
+    .id_stage_instr_rdata_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.instr_rdata_i),
+    .apu_req(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.apu_req_o),
+    .apu_gnt(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.apu_gnt_i),
+    .apu_busy(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.apu_busy_i),
+    .apu_op(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.apu_op_o),
+    .apu_rvalid_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.apu_rvalid_i),
+    .apu_perf_wb_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.apu_perf_wb_o),
+    .id_stage_apu_op_ex_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.apu_op_ex_o),
+    .id_stage_apu_en_ex_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.apu_en_ex_o),
+    .regfile_waddr_wb_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.regfile_waddr_wb_o),
+    .regfile_we_wb_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.regfile_we_wb_o),
+    .regfile_alu_waddr_ex_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.regfile_alu_waddr_fw_o),
+    .regfile_alu_we_ex_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.regfile_alu_we_fw_o),
+    .ex_mulh_active(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.mulh_active),
+    .ex_mult_op_ex(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.mult_operator_i),
+    .ex_data_misaligned_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.data_misaligned_i),
+    .ex_data_misaligned_ex_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.data_misaligned_ex_i),
+    .ex_data_req_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.data_req_i),
+    .ex_data_rvalid_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.data_rvalid_i),
+    .ex_regfile_alu_we_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.regfile_alu_we_i),
+    .ex_apu_valid(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.apu_valid),
+    .ex_apu_rvalid_q(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.apu_rvalid_q)
+  );
+
   // Instantiate debug assertions
   uvmt_cv32e40p_debug_assert u_debug_assert(.cov_assert_if(debug_cov_assert_if));
 
@@ -601,6 +632,7 @@ module uvmt_cv32e40p_tb;
      uvm_config_db#(virtual uvmt_cv32e40p_debug_cov_assert_if)::set(.cntxt(null), .inst_name("*.env"),                        .field_name("debug_cov_vif"),    .value(debug_cov_assert_if)                             );
      uvm_config_db#(virtual uvmt_cv32e40p_isa_covg_if        )::set(.cntxt(null), .inst_name("*.env"),                        .field_name("isa_covg_vif"),     .value(isa_covg_if)                                     );
      uvm_config_db#(virtual uvma_debug_if                    )::set(.cntxt(null), .inst_name("*.env"),                        .field_name("debug_vif"),        .value(debug_if)                                        );
+     uvm_config_db#(virtual uvmt_cv32e40p_cov_if             )::set(.cntxt(null), .inst_name("*.env"),                        .field_name("cov_vif"),          .value(cov_if)                                          );
 
      `RVFI_CSR_UVM_CONFIG_DB_SET(fflags)
      `RVFI_CSR_UVM_CONFIG_DB_SET(frm)


### PR DESCRIPTION
This is PR for floating point specific custom coverage block based on testplan and core's u-arch and pipeline design.

Mainly a rework of an older PR: from OHG core-v-verif repo PR - 1990

Now in this rework all the ifdefs are removed from the coverage model, using with syntax to achieve the same behaviour.

Kept most of the old reviewed coverpints and covergroups.

Improve the code indentation and structure.

Not part of this PR:
- ISACOV update for floating point instructions - multicycle cases