### PR TITLE
TB updates and improvements for ww48

### DIFF
--- a/cv32e40p/env/corev-dv/cv32e40p_asm_program_gen.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_asm_program_gen.sv
@@ -527,8 +527,10 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
   // Replace pop_gpr_from_kernel_stack with pop_regfile_from_kernel_stack
   // With RV32X enabled, check for ecall instr on the last instr of hwloop
   // If true, then
-  // (a) Set MEPC to first instr of hwloop body
-  // (b) Add logic to decrement the LPCOUNT
+  // (a) Set MEPC to first instr of hwloop body if LPCOUNTx >= 2
+  // (b) Decrement the LPCOUNTx if LPCOUNTx >= 1
+  // Else
+  // By Default for all other cases increment MEPC by 4
   virtual function void gen_ecall_handler(int hart);
     string instr[$];
     cv32e40p_instr_gen_config corev_cfg;
@@ -537,7 +539,7 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
 
     if (riscv_instr_pkg::RV32X inside {riscv_instr_pkg::supported_isa}) begin
       instr = {instr,
-               `COMMON_HWLOOP_EXC_HANDLING_CODE
+               `COMMON_EXCEPTION_XEPC_HANDLING_CODE_WITH_HWLOOP_CHECK(cfg.gpr[0],cfg.gpr[1],MEPC)
       };
     end else begin
       instr = {instr,
@@ -555,8 +557,10 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
   // Replace pop_gpr_from_kernel_stack with pop_regfile_from_kernel_stack
   // With RV32X enabled, check for ebreak instr on the last instr of hwloop
   // If true, then
-  // (a) Set MEPC to first instr of hwloop body
-  // (b) Add logic to decrement the LPCOUNT
+  // (a) Set MEPC to first instr of hwloop body if LPCOUNTx >= 2
+  // (b) Decrement the LPCOUNTx if LPCOUNTx >= 1
+  // Else
+  // By Default for all other cases increment MEPC by 4
   virtual function void gen_ebreak_handler(int hart);
     string instr[$];
     cv32e40p_instr_gen_config corev_cfg;
@@ -567,7 +571,7 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
     gen_signature_handshake(.instr(instr), .signature_type(WRITE_CSR), .csr(MCAUSE));
     if (riscv_instr_pkg::RV32X inside {riscv_instr_pkg::supported_isa}) begin
       instr = {instr,
-               `COMMON_HWLOOP_EXC_HANDLING_CODE
+               `COMMON_EXCEPTION_XEPC_HANDLING_CODE_WITH_HWLOOP_CHECK(cfg.gpr[0],cfg.gpr[1],MEPC)
       };
     end else begin
       instr = {instr,
@@ -586,8 +590,10 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
   // Replace pop_gpr_from_kernel_stack with pop_regfile_from_kernel_stack
   // With RV32X enabled, check for illegal instr on the last instr of hwloop
   // If true, then
-  // (a) Set MEPC to first instr of hwloop body
-  // (b) Add logic to decrement the LPCOUNT
+  // (a) Set MEPC to first instr of hwloop body if LPCOUNTx >= 2
+  // (b) Decrement the LPCOUNTx if LPCOUNTx >= 1
+  // Else
+  // By Default for all other cases increment MEPC by 4
   virtual function void gen_illegal_instr_handler(int hart);
     string instr[$];
     cv32e40p_instr_gen_config corev_cfg;
@@ -598,7 +604,7 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
     gen_signature_handshake(.instr(instr), .signature_type(WRITE_CSR), .csr(MCAUSE));
     if (riscv_instr_pkg::RV32X inside {riscv_instr_pkg::supported_isa}) begin
       instr = {instr,
-               `COMMON_HWLOOP_EXC_HANDLING_CODE
+               `COMMON_EXCEPTION_XEPC_HANDLING_CODE_WITH_HWLOOP_CHECK(cfg.gpr[0],cfg.gpr[1],MEPC)
       };
     end else begin
       instr = {instr,

--- a/cv32e40p/env/uvme/cov/uvme_cv32e40p_zfinx_instr_covg.sv
+++ b/cv32e40p/env/uvme/cov/uvme_cv32e40p_zfinx_instr_covg.sv
@@ -35,16 +35,13 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
     extern task run_phase(uvm_phase phase);
     extern task sample_clk_i();
 
-    `define FPU_LAT_0_2_EX_REGFILE_ALU_WR_NO_STALL_COND \
-     (cp_is_mulh_ex == 0) & (cp_is_misaligned_data_req_ex == 0) & (cp_is_post_inc_ld_st_inst_ex == 0) & (cp_ex_apu_valid_memorised == 0)
-
     `define FPU_MULTICYCLE_WINDOW_ILLEGAL_CASES \
      illegal_bins clk_2_19_group_NON_DIVSQRT  = ( (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1}) ) \
-                                                   with ( (cp_f_multicycle_clk_window != 0) & (fpu_latency == 0) & `FPU_LAT_0_2_EX_REGFILE_ALU_WR_NO_STALL_COND ); \
+                                                   with ( (cp_f_multicycle_clk_window != 0) & (fpu_latency == 0) ); \
      illegal_bins clk_3_19_group_NON_DIVSQRT  = ( (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1, 2}) ) \
-                                                   with ( (cp_f_multicycle_clk_window != 0) & (fpu_latency == 1) & `FPU_LAT_0_2_EX_REGFILE_ALU_WR_NO_STALL_COND ); \
+                                                   with ( (cp_f_multicycle_clk_window != 0) & (fpu_latency == 1) ); \
      illegal_bins clk_4_19_group_NON_DIVSQRT  = ( (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1, 2, 3}) ) \
-                                                   with ( (cp_f_multicycle_clk_window != 0) & (fpu_latency == 2) & `FPU_LAT_0_2_EX_REGFILE_ALU_WR_NO_STALL_COND );
+                                                   with ( (cp_f_multicycle_clk_window != 0) & (fpu_latency == 2) );
 
     `define FPU_ZERO_LATENCY_ILLEGAL_BUSY \
      illegal_bins apu_busy_curr_apu_op_not_div_sqrt = ( !binsof(cp_curr_fpu_apu_op_multicycle) intersect {APU_OP_FDIV, APU_OP_FSQRT} ) \
@@ -79,9 +76,6 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
     `define IGNORE_BINS_NO_CONTENTION_LSU \
      ignore_bins no_contention_lsu_wr = binsof(cp_apu_contention) intersect {0};
 
-    `define CP_FOR_USE_WITH_WITH_CONSTRUCT_EXCLUDING_SPECIAL_CASES \
-     cp_is_mulh_ex, cp_is_misaligned_data_req_ex, cp_is_post_inc_ld_st_inst_ex, cp_ex_apu_valid_memorised
-
     /*
     * Covergroups
     */
@@ -105,7 +99,10 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
             option.weight = 5;
         }
 
-        cp_f_multicycle_clk_window : coverpoint cntxt.cov_vif.if_clk_cycle_window {
+        cp_f_multicycle_clk_window : coverpoint cntxt.cov_vif.if_clk_cycle_window iff ((`COVIF_CB.is_mulh_ex == 0) &&
+                                                                                       (`COVIF_CB.is_misaligned_data_req_ex == 0) &&
+                                                                                       (`COVIF_CB.is_post_inc_ld_st_inst_ex == 0) &&
+                                                                                       (`COVIF_CB.ex_apu_valid_memorised == 0)) {
             bins clk1 = {1};
             bins clk2 = {2};
             bins clk3 = {3};
@@ -178,23 +175,12 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
             option.weight = 5;
         }
 
-        cp_is_mulh_ex : coverpoint cntxt.cov_vif.is_mulh_ex {
-            bins not_mulh = {1'b0};
-            option.weight = 1;
-        }
+        cp_fpu_lat_0_and_2_ex_regfile_alu_wr_no_stall : coverpoint ((cntxt.cov_vif.is_mulh_ex == 0) &&
+                                                                    (cntxt.cov_vif.is_misaligned_data_req_ex == 0) &&
+                                                                    (cntxt.cov_vif.is_post_inc_ld_st_inst_ex == 0) &&
+                                                                    (cntxt.cov_vif.ex_apu_valid_memorised == 0)) {
 
-        cp_is_misaligned_data_req_ex : coverpoint cntxt.cov_vif.is_misaligned_data_req_ex {
-            bins not_misaligned_data_req_ex = {1'b0};
-            option.weight = 1;
-        }
-
-        cp_is_post_inc_ld_st_inst_ex : coverpoint cntxt.cov_vif.is_post_inc_ld_st_inst_ex {
-            bins not_post_inc_ld_st_inst_ex = {1'b0};
-            option.weight = 1;
-        }
-
-        cp_ex_apu_valid_memorised : coverpoint cntxt.cov_vif.ex_apu_valid_memorised {
-            bins not_apu_valid_mem = {1'b0};
+            bins no_alu_wr_stall = {1};
             option.weight = 1;
         }
 
@@ -217,7 +203,7 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
         cr_f_inst_at_id_stage_inp_with_cyc_window_of_ongoing_fpu_calc : cross cp_id_stage_f_inst,
                                                                               cp_f_multicycle_clk_window,
                                                                               cp_curr_fpu_apu_op,
-                                                                              `CP_FOR_USE_WITH_WITH_CONSTRUCT_EXCLUDING_SPECIAL_CASES {
+                                                                              cp_fpu_lat_0_and_2_ex_regfile_alu_wr_no_stall {
             option.weight = 50;
             `FPU_MULTICYCLE_WINDOW_ILLEGAL_CASES
         }
@@ -225,9 +211,9 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
         // cross coverage for F-inst at ID-stage output with preceeding F-multicycle instr
         // Note: Added 2 separate similar cross coverages ID stage because of different
         // arrival times of next instruction w.r.t APU Req
-        cr_f_inst_at_id_stage_out_with_fpu_multicycle_req : cross cp_id_stage_apu_op_ex_o,
-                                                                  cp_curr_fpu_apu_op_at_apu_req
-        {option.weight = 50;}
+        //cr_f_inst_at_id_stage_out_with_fpu_multicycle_req : cross cp_id_stage_apu_op_ex_o,
+        //                                                          cp_curr_fpu_apu_op_at_apu_req
+        //{option.weight = 50;}
 
         // cross coverage for F-inst at ID-stage output with preceeding F-multicycle
         // case with apu_busy or APU needing more than 1 clock cycle 
@@ -246,7 +232,7 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
         cr_f_inst_at_id_stage_out_with_cyc_window_of_ongoing_fpu_calc : cross cp_id_stage_apu_op_ex_o,
                                                                               cp_f_multicycle_clk_window,
                                                                               cp_curr_fpu_apu_op,
-                                                                              `CP_FOR_USE_WITH_WITH_CONSTRUCT_EXCLUDING_SPECIAL_CASES {
+                                                                              cp_fpu_lat_0_and_2_ex_regfile_alu_wr_no_stall {
 
             option.weight = 50;
             `FPU_MULTICYCLE_WINDOW_ILLEGAL_CASES
@@ -270,7 +256,7 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
         cr_f_inst_at_if_stage_inp_with_cyc_window_of_ongoing_fpu_calc : cross cp_if_stage_f_inst,
                                                                               cp_f_multicycle_clk_window,
                                                                               cp_curr_fpu_apu_op,
-                                                                              `CP_FOR_USE_WITH_WITH_CONSTRUCT_EXCLUDING_SPECIAL_CASES {
+                                                                              cp_fpu_lat_0_and_2_ex_regfile_alu_wr_no_stall {
 
             option.weight = 50;
             `FPU_MULTICYCLE_WINDOW_ILLEGAL_CASES
@@ -358,20 +344,24 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
             bins fs1[] = {[0:31]};
             option.weight = 1;
         }
+
         cp_id_f_inst_fs2 : coverpoint `COVIF_CB.id_stage_instr_rdata_i[24:20]
                                       iff (`COVIF_CB.id_stage_instr_valid_i == 1) {
 
             bins fs2[] = {[0:31]};
             option.weight = 1;
         }
+
         cp_curr_fpu_inst_fd : coverpoint cntxt.cov_vif.curr_fpu_fd {
             bins fd[] = {[0:31]};
             option.weight = 1;
         }
+
         cp_curr_fpu_inst_rd : coverpoint cntxt.cov_vif.curr_fpu_rd {
             bins rd[] = {[0:31]};
             option.weight = 1;
         }
+
         cp_curr_fpu_inst_rd_for_0_lat_apu_result : coverpoint cntxt.cov_vif.curr_fpu_rd
                                                               iff ( (`COVIF_CB.apu_req == 1) && 
                                                                     (`COVIF_CB.apu_gnt == 1) &&         
@@ -380,18 +370,12 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
             bins rd[] = {[0:31]};
             option.weight = 1;
         }
+
         cp_curr_fpu_inst_rd_for_multicyc_lat_apu_result : coverpoint cntxt.cov_vif.curr_fpu_rd
                                                                      iff ( (`COVIF_CB.apu_busy == 1) && 
                                                                            (`COVIF_CB.apu_rvalid_i == 1) ) {
 
             bins rd[] = {[0:31]};
-            option.weight = 1;
-        }
-        cp_id_x_inst_rs1 : coverpoint `COVIF_CB.id_stage_instr_rdata_i[19:15]
-                                      iff (`COVIF_CB.id_stage_instr_valid_i == 1) {
-
-
-            bins rs1[] = {[0:31]};
             option.weight = 1;
         }
 
@@ -400,11 +384,13 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
             illegal_bins rd_addr_32_63 = {[32:63]};
             option.weight = 1;
         }
+
         cp_lsu_apu_contention_wr_rd : coverpoint cntxt.cov_vif.curr_rd_at_wb_regfile_wr_contention {
             bins rd[] = {[0:31]} with ( (item < 32) & (fpu_latency == 1) );
             illegal_bins rd_addr_32_63 = {[32:63]};
             option.weight = 1;
         }
+
         cp_prev_rd_waddr_contention : coverpoint cntxt.cov_vif.prev_rd_waddr_contention {
             bins rd[] = {[0:31]};
             illegal_bins rd_addr_32_63 = {[32:63]};  //for zfinx only 32 gprs available
@@ -429,19 +415,23 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
 
             bins rd_rs1_equal = {1};
         }
+
         cp_rd_rs2_eq : coverpoint (`COVIF_CB.id_stage_instr_rdata_i[24:20] == cntxt.cov_vif.curr_fpu_rd)
                                   iff (`COVIF_CB.id_stage_instr_valid_i == 1) {
 
             bins rd_rs2_equal = {1};
         }
+
         cp_rd_rs3_eq : coverpoint (`COVIF_CB.id_stage_instr_rdata_i[31:27] == cntxt.cov_vif.curr_fpu_rd)
                                   iff (`COVIF_CB.id_stage_instr_valid_i == 1) {
 
             bins rd_rs3_equal = {1};
         }
+
         cp_contention_rd_rd_eq : coverpoint (cntxt.cov_vif.curr_rd_at_ex_regfile_wr_contention == cntxt.cov_vif.prev_rd_waddr_contention) {
             bins contention_rd_rd_equal = {1} with ( (item == 1) & (fpu_latency != 1) );
         }
+
         cp_contention_rd_rd_eq_fpu_lat_1 : coverpoint (cntxt.cov_vif.curr_fpu_rd == cntxt.cov_vif.prev_rd_waddr_contention) {
             bins contention_rd_rd_equal = {1}  with ( (item == 1) & (fpu_latency == 1) );
         }
@@ -457,11 +447,11 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
 
         // cross coverage for F-instr following F-instr with rd to rs1 dependency
         // case with APU latency > 0
-        cr_rd_rs1_eq_nonzero_lat  :  cross cp_rd_rs1_eq,
-                                           cp_id_stage_f_inst,
-                                           cp_curr_fpu_inst_rd_for_multicyc_lat_apu_result,
-                                           cp_curr_fpu_apu_op,
-                                           cp_apu_contention {
+        cr_rd_rs1_eq_nonzero_lat  : cross cp_rd_rs1_eq,
+                                          cp_id_stage_f_inst,
+                                          cp_curr_fpu_inst_rd_for_multicyc_lat_apu_result,
+                                          cp_curr_fpu_apu_op,
+                                          cp_apu_contention {
 
             option.weight = 50;
             `IGNORE_BINS_ZERO_LAT_FPU_OP
@@ -470,11 +460,11 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
 
         // cross coverage for F-instr following F-instr with rd to rs2 dependency
         // case with APU latency > 0
-        cr_rd_rs2_eq_nonzero_lat  :  cross cp_rd_rs2_eq,
-                                           cp_id_stage_f_inst,
-                                           cp_curr_fpu_inst_rd_for_multicyc_lat_apu_result,
-                                           cp_curr_fpu_apu_op,
-                                           cp_apu_contention {
+        cr_rd_rs2_eq_nonzero_lat  : cross cp_rd_rs2_eq,
+                                          cp_id_stage_f_inst,
+                                          cp_curr_fpu_inst_rd_for_multicyc_lat_apu_result,
+                                          cp_curr_fpu_apu_op,
+                                          cp_apu_contention {
 
             option.weight = 50;
             `IGNORE_BINS_ZERO_LAT_FPU_OP
@@ -621,8 +611,8 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
                                                        cp_apu_contention {
 
             option.weight = 50;
-            bins main_cr_bin =  cr_rv32f_rd_non_rv32fc_rs2_eq_no_lat
-                                with ( (cp_rd_rs2_eq == 1) & (fpu_latency == 0) );
+            bins main_cr_bin = cr_rv32f_rd_non_rv32fc_rs2_eq_no_lat
+                               with ( (cp_rd_rs2_eq == 1) & (fpu_latency == 0) );
 
             `IGNORE_BINS_NON_RS2_CV32E40P_INSTR
         }

--- a/cv32e40p/sim/ExternalRepos.mk
+++ b/cv32e40p/sim/ExternalRepos.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40p
 CV_CORE_BRANCH ?= dev
-CV_CORE_HASH   ?= 1d0ec8d83091bda8e65c36c48614a41065f5fc10
+CV_CORE_HASH   ?= 6b34db2a91d0e208b2a4571b7531d7630d886df4
 CV_CORE_TAG    ?= none
 
 # The CV_CORE_HASH above points to version of the RTL that is newer.

--- a/cv32e40p/tb/uvmt/imperas_dv.flist
+++ b/cv32e40p/tb/uvmt/imperas_dv.flist
@@ -25,7 +25,7 @@
 +incdir+${IMPERAS_HOME}/ImpProprietary/include/host
 +incdir+${IMPERAS_HOME}/ImpProprietary/source/host/CV32E40Pv2_riscvISACOV/source
 
-//${TBSRC_HOME}/uvmt/uvmt_cv32e40p_imperas_riscv_coverage_config.svh
+${TBSRC_HOME}/uvmt/uvmt_cv32e40p_imperas_riscv_coverage_config.svh
 -f ${IMPERAS_HOME}/ImpPublic/source/host/rvvi/rvvi.f
 -f ${IMPERAS_HOME}/ImpProprietary/source/host/idv/idv.f
 

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_imperas_riscv_coverage_config.svh
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_imperas_riscv_coverage_config.svh
@@ -6,7 +6,7 @@
   `define IDV_INCLUDE_TRACE2COV
   `define COVER_BASE_RV32I
   `define COVER_LEVEL_COMPL_BAS
-  `define COVER_LEVEL_COMPL_EXT
+  //`define COVER_LEVEL_COMPL_EXT
   `define COVER_LEVEL_DV_UP_BAS
   `define COVER_LEVEL_DV_UP_EXT
   `define COVER_LEVEL_DV_PR_BAS
@@ -31,15 +31,15 @@
     `define COVER_RV32ZCF_ILLEGAL
   `endif
 
-  `ifdef PULP
-    `define COVER_XPULPV2
-    `ifdef CLUSTER
-      `define COVER_XPULPV2C
-    `else
-      `define COVER_XPULPV2C_ILLEGAL
-    `endif
-  `else
-    `define COVER_XPULPV2_ILLEGAL
-    `define COVER_XPULPV2C_ILLEGAL
-  `endif
+  //`ifdef PULP
+  //  `define COVER_XPULPV2
+  //  `ifdef CLUSTER
+  //    `define COVER_XPULPV2C
+  //  `else
+  //    `define COVER_XPULPV2C_ILLEGAL
+  //  `endif
+  //`else
+  //  `define COVER_XPULPV2_ILLEGAL
+  //  `define COVER_XPULPV2C_ILLEGAL
+  //`endif
 `endif

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb_ifs.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb_ifs.sv
@@ -552,6 +552,10 @@ interface uvmt_cv32e40p_cov_if
       input apu_perf_wb_o;
       input id_stage_apu_op_ex_o;
       input id_stage_apu_en_ex_o;
+      output is_mulh_ex;
+      output is_misaligned_data_req_ex;
+      output is_post_inc_ld_st_inst_ex;
+      output ex_apu_valid_memorised;
   endclocking : mon_cb
 
   //calculate each APU operation's current clock cycle number during execution for functional coverage use


### PR DESCRIPTION
Work in this PR:

- Improve cv32e40p_floating_pt/zfinx custom cover groups for :   
   (a) Remove some redundant coverpoints and covergroup  
   (b) Optimize crosses  
   (c)  Improve code readability  
   (d) More uniformity across both F/Zfinx cover groups  

- Modify macro COMMON_HWLOOP_EXC_HANDLING_CODE to more generic COMMON_EXCEPTION_XEPC_HANDLING_CODE_WITH_HWLOOP_CHECK(SCRATCH_REG0,SCRATCH_REG1,XEPC  
- Use this updated Macro for both traps and debug program, thereby also resolving issue of this piece of logic missing in debug program
  
- Re-enable ImerasDV ISACOV with PULP covergroup disabled
- Update core hash

- add randomize_avail_regs for cv32e40p_rand_instr_stream gen_instr to ensure this list is populated and used with correct constraints for default random generation