### PR TITLE
Cv32e40p/vja ww50 fixes

### DIFF
--- a/cv32e40p/env/corev-dv/cv32e40p_instr_sequence.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_instr_sequence.sv
@@ -175,12 +175,6 @@ class cv32e40p_instr_sequence extends riscv_instr_sequence;
           instr_stream.instr_list[i].has_label = 1'b0;
         end
       end
-      // Remove all pulp store instructions inside debug_program
-      if(is_debug_program == 1) begin
-        if (instr_stream.instr_list[i].instr_name inside {CV_SB, CV_SH, CV_SW} ) begin
-            instr_stream.instr_list.delete(i);
-        end
-      end
       i++;
     end // while
     `uvm_info(get_full_name(), "Finished post-processing instructions", UVM_HIGH)

--- a/cv32e40p/env/corev-dv/cv32e40p_rand_instr_stream.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_rand_instr_stream.sv
@@ -219,6 +219,7 @@ class cv32e40p_rand_instr_stream extends riscv_rand_instr_stream;
             1: randomize_debug_rom_instr(.instr(instr_list[i]), .is_in_debug(is_debug_program), .disable_dist());
             2: randomize_instr(instr_list[i], is_debug_program);
           endcase
+          store_instr_gpr_handling(instr_list[i]);
         end
     end
     else begin
@@ -264,6 +265,15 @@ class cv32e40p_rand_instr_stream extends riscv_rand_instr_stream;
     instr = riscv_instr::get_rand_instr(.exclude_instr(exclude_instr));
     instr.m_cfg = cfg;
     randomize_gpr(instr);
+  endfunction
+
+  // Function to assign reserved reg for store instr from cfg to avoid random
+  // reg operands for stores which may result in corruption of instr memory
+  function void store_instr_gpr_handling(riscv_instr instr);
+    if (instr.instr_name inside {SB, SH, SW, C_SW, C_FSW, FSW, CV_SB, CV_SH, CV_SW}) begin
+      instr.rs1 = cv32e40p_cfg.str_rs1;
+      instr.rd  = cv32e40p_cfg.str_rs3;
+    end
   endfunction
 
 endclass

--- a/cv32e40p/sim/ExternalRepos.mk
+++ b/cv32e40p/sim/ExternalRepos.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40p
 CV_CORE_BRANCH ?= dev
-CV_CORE_HASH   ?= 6b34db2a91d0e208b2a4571b7531d7630d886df4
+CV_CORE_HASH   ?= 61423d98758a0b61835bd7dcb382e8a33159cddb
 CV_CORE_TAG    ?= none
 
 # The CV_CORE_HASH above points to version of the RTL that is newer.


### PR DESCRIPTION
Work done in this PR:

- Update and fix for issues of random stores inside debug program.

    1. Fix by using same mechanism as used in main program : use initalised reserved gpr only for store instructions
    2. Add these reserved reg initialization separately for debug program
    3. Change order of these GPR initialization to be done before other GPR initalization to minimize issues with random debug requests before initalization completes

- Removed the previous work around which excluded the pulp store instructions in debug program. So now again all store instructions are allowed as part of random instructions inside debug program

- In cv32e40p_asm_program_gen class create a common cv32e40p_instr_gen_config object and remove all individual instances in various functions
