### PR TITLE
Updates for regress lists and v2 ci check

### DIFF
--- a/cv32e40p/regress/cv32e40pv2_ci_check.yaml
+++ b/cv32e40p/regress/cv32e40pv2_ci_check.yaml
@@ -48,40 +48,40 @@ builds:
     cfg: pulp_fpu_zfinx_2cyclat
     dir: cv32e40p/sim/uvmt
 
-  uvmt_cv32e40p_pulp_cluster:
-    cmd: make comp comp_corev-dv
-    cfg: pulp_cluster
-    dir: cv32e40p/sim/uvmt
-
-  uvmt_cv32e40p_pulp_cluster_fpu:
-    cmd: make comp comp_corev-dv
-    cfg: pulp_cluster_fpu
-    dir: cv32e40p/sim/uvmt
-
-  uvmt_cv32e40p_pulp_cluster_fpu_1cyclat:
-    cmd: make comp comp_corev-dv
-    cfg: pulp_cluster_fpu_1cyclat
-    dir: cv32e40p/sim/uvmt
-
-  uvmt_cv32e40p_pulp_cluster_fpu_2cyclat:
-    cmd: make comp comp_corev-dv
-    cfg: pulp_cluster_fpu_2cyclat
-    dir: cv32e40p/sim/uvmt
-
-  uvmt_cv32e40p_pulp_cluster_fpu_zfinx:
-    cmd: make comp comp_corev-dv
-    cfg: pulp_cluster_fpu_zfinx
-    dir: cv32e40p/sim/uvmt
-
-  uvmt_cv32e40p_pulp_cluster_fpu_zfinx_1cyclat:
-    cmd: make comp comp_corev-dv
-    cfg: pulp_cluster_fpu_zfinx_1cyclat
-    dir: cv32e40p/sim/uvmt
-
-  uvmt_cv32e40p_pulp_cluster_fpu_zfinx_2cyclat:
-    cmd: make comp comp_corev-dv
-    cfg: pulp_cluster_fpu_zfinx_2cyclat
-    dir: cv32e40p/sim/uvmt
+#  uvmt_cv32e40p_pulp_cluster:
+#    cmd: make comp comp_corev-dv
+#    cfg: pulp_cluster
+#    dir: cv32e40p/sim/uvmt
+#
+#  uvmt_cv32e40p_pulp_cluster_fpu:
+#    cmd: make comp comp_corev-dv
+#    cfg: pulp_cluster_fpu
+#    dir: cv32e40p/sim/uvmt
+#
+#  uvmt_cv32e40p_pulp_cluster_fpu_1cyclat:
+#    cmd: make comp comp_corev-dv
+#    cfg: pulp_cluster_fpu_1cyclat
+#    dir: cv32e40p/sim/uvmt
+#
+#  uvmt_cv32e40p_pulp_cluster_fpu_2cyclat:
+#    cmd: make comp comp_corev-dv
+#    cfg: pulp_cluster_fpu_2cyclat
+#    dir: cv32e40p/sim/uvmt
+#
+#  uvmt_cv32e40p_pulp_cluster_fpu_zfinx:
+#    cmd: make comp comp_corev-dv
+#    cfg: pulp_cluster_fpu_zfinx
+#    dir: cv32e40p/sim/uvmt
+#
+#  uvmt_cv32e40p_pulp_cluster_fpu_zfinx_1cyclat:
+#    cmd: make comp comp_corev-dv
+#    cfg: pulp_cluster_fpu_zfinx_1cyclat
+#    dir: cv32e40p/sim/uvmt
+#
+#  uvmt_cv32e40p_pulp_cluster_fpu_zfinx_2cyclat:
+#    cmd: make comp comp_corev-dv
+#    cfg: pulp_cluster_fpu_zfinx_2cyclat
+#    dir: cv32e40p/sim/uvmt
 
 tests:
   hello-world:
@@ -95,13 +95,6 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx
       - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
       - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
-      - uvmt_cv32e40p_pulp_cluster
-      - uvmt_cv32e40p_pulp_cluster_fpu
-      - uvmt_cv32e40p_pulp_cluster_fpu_1cyclat
-      - uvmt_cv32e40p_pulp_cluster_fpu_2cyclat
-      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx
-      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_1cyclat
-      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_2cyclat
     description: UVM Hello World Test
     dir: cv32e40p/sim/uvmt
     cmd: make test COREV=YES TEST=hello-world CFG_PLUSARGS="+UVM_TIMEOUT=1000000"
@@ -111,13 +104,13 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu
     description: Interrupt directed on PULP+FPU HW
     dir: cv32e40p/sim/uvmt
-    cmd: make test COREV=YES TEST=interrupt_test CFG_PLUSARGS="+UVM_TIMEOUT=1000000"
+    cmd: make test COREV=YES TEST=interrupt_test CFG_PLUSARGS="+UVM_TIMEOUT=20000000"
     num: 1
 
   debug_test:
     build: uvmt_cv32e40p_pulp_fpu
     dir: cv32e40p/sim/uvmt
-    cmd: make test COREV=YES TEST=debug_test CFG_PLUSARGS="+UVM_TIMEOUT=1000000"
+    cmd: make test COREV=YES TEST=debug_test CFG_PLUSARGS="+UVM_TIMEOUT=20000000"
     num: 1
 
   corev_rand_fp_instr_sanity_test:
@@ -147,4 +140,4 @@ tests:
   corev_rand_pulp_hwloop_test:
     build: uvmt_cv32e40p_pulp
     dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_hwloop_test CFG_PLUSARGS="+UVM_TIMEOUT=1000000"
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_hwloop_test CFG_PLUSARGS="+UVM_TIMEOUT=20000000"

--- a/cv32e40p/regress/cv32e40pv2_interrupt_debug_long.yaml
+++ b/cv32e40p/regress/cv32e40pv2_interrupt_debug_long.yaml
@@ -119,3 +119,11 @@ tests:
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
     test_cfg: debug_single_step_en
 
+  corev_rand_pulp_hwloop_exception_with_int_debug_trigger:
+    testname: corev_rand_pulp_hwloop_exception
+    description: hwloop exception test with interrupt and debug trigger
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=20000000"
+    test_cfg: gen_rand_int,debug_trigger_basic
+

--- a/cv32e40p/regress/cv32e40pv2_interrupt_debug_short.yaml
+++ b/cv32e40p/regress/cv32e40pv2_interrupt_debug_short.yaml
@@ -115,14 +115,6 @@ tests:
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=20000000"
     test_cfg: debug_trigger_basic
 
-  corev_rand_pulp_hwloop_exception_with_int_debug_trigger:
-    testname: corev_rand_pulp_hwloop_exception
-    description: hwloop exception test with interrupt and debug trigger
-    build: uvmt_cv32e40p
-    dir: cv32e40p/sim/uvmt
-    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=20000000"
-    test_cfg: gen_rand_int,debug_trigger_basic
-
   debug_test:
     build: uvmt_cv32e40p
     description: debug_test (adapted from v1)

--- a/cv32e40p/sim/ExternalRepos.mk
+++ b/cv32e40p/sim/ExternalRepos.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40p
 CV_CORE_BRANCH ?= dev
-CV_CORE_HASH   ?= 61423d98758a0b61835bd7dcb382e8a33159cddb
+CV_CORE_HASH   ?= 11e24901f5a6c8e265250d26d211c3ddfd3a502d
 CV_CORE_TAG    ?= none
 
 # The CV_CORE_HASH above points to version of the RTL that is newer.


### PR DESCRIPTION
Work done in this PR:

1. Remove cluster config builds and tests from v2 ci check regress list
2. move 1 test for interrupt to long list
3. update core hash