### PR TITLE
Debug assertion correction.

### DIFF
--- a/bin/run_embench.py
+++ b/bin/run_embench.py
@@ -190,6 +190,7 @@ def main():
          f'--ldflags=-T{paths["bsp"]}/link.ld',
          f'--builddir={args.builddir}',
          f'--logdir={args.logdir}',
+         f'--timeout=15',
          '--clean']
   logger.info(f"Calling build script: {' '.join(cmd)}")
   try:

--- a/cv32e40p/tests/programs/custom/coremark/test.yaml
+++ b/cv32e40p/tests/programs/custom/coremark/test.yaml
@@ -3,7 +3,8 @@ uvm_test: uvmt_cv32e40p_firmware_test_c
 default_cflags: >
     -O3
     -mabi=ilp32
-    -march=rv32im
+    -march=$(RISCV_MARCH)
+    -msave-restore
     -falign-functions=16
     -funroll-all-loops
     -falign-jumps=4
@@ -14,6 +15,6 @@ default_cflags: >
     -DPERFORMANCE_RUN=1
     -DITERATIONS=30
     -DHAS_STDIO=1 -DHAS_PRINTF=1 -DHAS_FLOAT=1
-    -DFLAGS_STR=\""-mabi=ilp32 -march=rv32im -O3 -falign-functions=16 -funroll-all-loops -falign-jumps=4 -finline-functions -Wall -pedantic -nostartfiles -static -DPERFORMANCE_RUN=1 -DITERATIONS=30 -DHAS_STDIO=1 -DHAS_PRINTF=1 -DHAS_FLOAT=1"\"
+    -DFLAGS_STR=\""-O3 -mabi=ilp32 -march=$(RISCV_MARCH) -msave-restore -falign-functions=16 -funroll-all-loops -falign-jumps=4 -finline-functions -Wall -static -pedantic -nostartfiles -DPERFORMANCE_RUN=1 -DITERATIONS=30 -DHAS_STDIO=1 -DHAS_PRINTF=1 -DHAS_FLOAT=1"\"
 description: >
     Runs the CoreMark benchmark

--- a/cv32e40p/tests/programs/custom/fpu_bugs_test/test.c
+++ b/cv32e40p/tests/programs/custom/fpu_bugs_test/test.c
@@ -26,9 +26,10 @@
 void fp_enable ()
 {
   unsigned int fs = MSTATUS_FS_INITIAL;
-  __asm__ volatile("csrs mstatus, %0;"
-                   "csrwi fcsr, 0;"
-                   : : "r"(fs));
+
+  asm volatile("csrwi fcsr, 0;"
+               "csrs mstatus, %0;"
+               : : "r"(fs));
 }
 
 const long int INPUT[10] __attribute__ ((aligned (4))) = {

--- a/cv32e40p/tests/programs/custom/interrupt_test/interrupt_test.c
+++ b/cv32e40p/tests/programs/custom/interrupt_test/interrupt_test.c
@@ -46,8 +46,8 @@ void fp_enable ()
 {
   unsigned int fs = MSTATUS_FS_INITIAL;
 
-  asm volatile("csrs mstatus, %0;"
-               "csrwi fcsr, 0;"
+  asm volatile("csrwi fcsr, 0;"
+               "csrs mstatus, %0;"
                : : "r"(fs));
 }
 #endif

--- a/cv32e40p/tests/programs/custom/matmul_32b_float/test.c
+++ b/cv32e40p/tests/programs/custom/matmul_32b_float/test.c
@@ -47,8 +47,9 @@ int checkInt (long int *B, long int *A, long int n)
 void fp_enable ()
 {
   unsigned int fs = MSTATUS_FS_INITIAL;
-  __asm__ volatile("csrs mstatus, %0;"
-                   "csrwi fcsr, 0;"
+
+  __asm__ volatile("csrwi fcsr, 0;"
+                   "csrs mstatus, %0;"
                    : : "r"(fs));
 }
 #endif


### PR DESCRIPTION
- Issue [#45](https://gitlab.dolphin.fr/speed_processing/ml_ai_processing/cv32e40p/cv32e40p-ohg/design/-/issues/45) final correction
- Increased a bit Embench test compilation timeout.
- Corrected Coremark compilation options and added context save/restore switch.
- Inverted csr writes in floating point enable function to have a clean status after its execution.