### PR TITLE
Temporary workaround for GNU GCC issue #36

### DIFF
--- a/cv32e40p/tests/programs/custom/pulp_hardware_loop_interrupt_test/pulp_hardware_loop_interrupt_test.c
+++ b/cv32e40p/tests/programs/custom/pulp_hardware_loop_interrupt_test/pulp_hardware_loop_interrupt_test.c
@@ -216,8 +216,28 @@ __attribute__((interrupt ("machine"))) void u_sw_direct_irq_handler(void)  {
 	    "j u_sw_irq_handler\n"	
     );
 
+#ifdef FPU
+#define MSTATUS_FS_INITIAL 0x00002000
+
+void fp_enable ()
+{
+  unsigned int fs = MSTATUS_FS_INITIAL;
+
+  asm volatile("csrs mstatus, %0;"
+               "csrwi fcsr, 0;"
+               "csrs mstatus, %0;"
+               : : "r"(fs)
+              );
+}
+#endif
+
 int main(int argc, char *argv[]) {
     int retval;
+
+#ifdef FPU
+    // Floating Point enable
+    fp_enable();
+#endif
 
     // Test 1
     retval = test1();


### PR DESCRIPTION
GNU GCC issue [#36](https://github.com/openhwgroup/corev-gcc/issues/36)
Interrupt routine preamble generated by GCC compiler accessing FCSR/FREGS without checking MSTATUS.FS

Temporary work-around is to enable FPU for FPU configurations even if this test is not using FPU instructions.