### PR TITLE
Fixes for regression failures, coverage issues and new tests for debug and interrupts

### DIFF
--- a/cv32e40p/env/corev-dv/custom/isa/custom/riscv_custom_instr.sv
+++ b/cv32e40p/env/corev-dv/custom/isa/custom/riscv_custom_instr.sv
@@ -230,7 +230,7 @@ class cv32e40p_instr extends riscv_instr;
     // special overrides for xcorev
 
     // for ALU, there exists variations for R and S types
-    if (category == ALU) begin
+    if (category inside {ALU,MAC}) begin
       if (instr_name inside {CV_CLIP, CV_CLIPU}) has_imm = 1'b1;
       if (format == S_FORMAT) has_rd = 1'b1;
     end
@@ -698,7 +698,7 @@ class cv32e40p_instr extends riscv_instr;
         imm_str = $sformatf("%0d", $signed(imm[5:0]));
       end
     end else
-    super.update_imm_str();
+      super.update_imm_str();
   endfunction
 
   // `include "isa/riscv_instr_cov.svh"

--- a/cv32e40p/env/corev-dv/cv32e40p_rand_instr_stream.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_rand_instr_stream.sv
@@ -261,7 +261,7 @@ class cv32e40p_rand_instr_stream extends riscv_rand_instr_stream;
       exclude_instr = {exclude_instr, CV_BEQIMM, CV_BNEIMM, BEQ, BNE, BLT, BGE, BLTU, BGEU, C_BEQZ, C_BNEZ, JALR, JAL, C_JR, C_JALR, C_J, C_JAL};
     end
 
-    exclude_instr = {exclude_instr, CV_START, CV_STARTI, CV_END, CV_ENDI, CV_COUNT, CV_COUNTI, CV_SETUP, CV_SETUPI, CV_ELW, C_ADDI16SP, URET, SRET, MRET, DRET, ECALL};
+    exclude_instr = {exclude_instr, CV_START, CV_STARTI, CV_END, CV_ENDI, CV_COUNT, CV_COUNTI, CV_SETUP, CV_SETUPI, CV_ELW, C_ADDI16SP, C_SWSP, C_FSWSP, URET, SRET, MRET, DRET, ECALL};
     instr = riscv_instr::get_rand_instr(.exclude_instr(exclude_instr));
     instr.m_cfg = cfg;
     randomize_gpr(instr);

--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_hwloop_instr_lib.sv
@@ -277,6 +277,34 @@ class cv32e40p_xpulp_hwloop_base_stream extends cv32e40p_xpulp_rand_stream;
         `uvm_fatal(this.get_type_name(), "cv32e40p_exclude_regs out of range")
       end
 
+      // Ensure the illegal inserted in the sequence function cv32e40p_insert_illegal_hint_instr()
+      // does not violate the hwloop end label offset limits with cv.setupi instr
+      // As a workaround here if illegal_instr_ratio is non-zero,
+      // The number of instructions in hwloop are reduced by 3(Change if
+      // needed), to allow illegal/hint instr insertion in the sequence.
+      // The coverage here is not critical as the max range with cv.setupi
+      // will be exercised in tests without illegals.
+      if (cfg.illegal_instr_ratio > 0) begin
+        if(gen_nested_loop) begin
+          if (use_setup_inst[1] && use_loop_setupi_inst[1] && (num_hwloop_instr[1] >= 28)) begin
+            num_hwloop_instr[1] = num_hwloop_instr[1] - 3;
+            if (num_hwloop_instr[0] >= 6)
+              num_hwloop_instr[0] = num_hwloop_instr[0] - 3;
+            else
+              num_hwloop_instr[0] = 3;
+          end else if (use_setup_inst[0] && use_loop_setupi_inst[0] && (num_hwloop_instr[0] >= 28)) begin
+            num_hwloop_instr[0] = num_hwloop_instr[0] - 3;
+          end
+        end else begin
+          if (use_setup_inst[1] && use_loop_setupi_inst[1] && (num_hwloop_instr[1] >= 28)) begin
+            num_hwloop_instr[1] = num_hwloop_instr[1] - 3;
+          end
+          if (use_setup_inst[0] && use_loop_setupi_inst[0] && (num_hwloop_instr[0] >= 28)) begin
+            num_hwloop_instr[0] = num_hwloop_instr[0] - 3;
+          end
+        end
+      end
+
       gen_xpulp_hwloop_control_instr();
   endfunction : post_randomize
 

--- a/cv32e40p/regress/cv32e40pv2_interrupt_debug_long.yaml
+++ b/cv32e40p/regress/cv32e40pv2_interrupt_debug_long.yaml
@@ -103,6 +103,14 @@ tests:
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
     test_cfg: debug_trigger_basic,debug_single_step_en
 
+  corev_rand_pulp_hwloop_debug_with_int_debug_trigger_and_ebreak:
+    testname: corev_rand_pulp_hwloop_debug
+    description: hwloop debug with interrupt, debug trigger and ebreak random test
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+    test_cfg: gen_rand_int,debug_trigger_basic,debug_ebreak
+
   corev_rand_pulp_hwloop_debug_with_int_debug_trigger_single_step:
     testname: corev_rand_pulp_hwloop_debug
     description: hwloop debug with interrupt, debug trigger and single step random test

--- a/cv32e40p/regress/cv32e40pv2_interrupt_debug_short.yaml
+++ b/cv32e40p/regress/cv32e40pv2_interrupt_debug_short.yaml
@@ -21,6 +21,14 @@ builds:
 
 # List of tests
 tests:
+  corev_rand_pulp_instr_random_debug_test:
+    testname: corev_rand_pulp_instr_test
+    description: pulp instr test with random debug halt req
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_test CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: gen_rand_debug_req
+
   corev_rand_pulp_instr_ebreak_debug_test:
     testname: corev_rand_pulp_instr_debug
     description: pulp rand test with ebreak debug
@@ -45,6 +53,46 @@ tests:
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
     test_cfg: debug_trigger_basic
 
+  corev_rand_pulp_instr_debug_trigger_with_ebreak:
+    testname: corev_rand_pulp_instr_debug
+    description: pulp rand test with debug trigger and ebreak
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: debug_trigger_basic,debug_ebreak
+
+  corev_rand_pulp_instr_debug_trigger_with_single_step:
+    testname: corev_rand_pulp_instr_debug
+    description: pulp rand test with debug trigger and single step
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: debug_trigger_basic,debug_single_step_en
+
+  corev_rand_pulp_instr_debug_trigger_with_random_debug_req:
+    testname: corev_rand_pulp_instr_debug
+    description: pulp rand test with debug trigger and random debug req
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_test CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: debug_trigger_basic,gen_rand_debug_req
+
+  corev_rand_pulp_instr_debug_ebreak_with_random_debug_req:
+    testname: corev_rand_pulp_instr_debug
+    description: pulp rand test with debug ebreak and random debug req
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_test CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: debug_ebreak,gen_rand_debug_req
+
+  corev_rand_pulp_instr_debug_single_step_with_random_debug_req:
+    testname: corev_rand_pulp_instr_debug
+    description: pulp rand test with debug ebreak and random debug req
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_test CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: debug_single_step_en,gen_rand_debug_req
+
   corev_rand_pulp_instr_interrupt_test:
     testname: corev_rand_pulp_instr_test
     description: pulp instr test with random interrupts
@@ -53,11 +101,67 @@ tests:
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_test CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
     test_cfg: gen_rand_int
 
+  corev_rand_pulp_instr_interrupt_debug_test:
+    testname: corev_rand_pulp_instr_test
+    description: pulp instr test with random interrupts and debug halt req
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_test CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: gen_rand_int,gen_rand_debug_req
+
+  corev_rand_pulp_instr_debug_test_with_int_and_debug_trigger:
+    testname: corev_rand_pulp_instr_debug
+    description: pulp instr random test with random interrupt and debug trigger
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: gen_rand_int,debug_trigger_basic
+
+  corev_rand_pulp_instr_debug_test_with_int_and_debug_single_step:
+    testname: corev_rand_pulp_instr_debug
+    description: pulp instr random test with random interrupt and debug trigger
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: gen_rand_int,debug_single_step_en
+
+  corev_rand_pulp_instr_debug_test_with_int_and_debug_ebreak:
+    testname: corev_rand_pulp_instr_debug
+    description: pulp instr random test with random interrupt and debug ebreak
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: gen_rand_int,debug_ebreak
+
+  corev_rand_pulp_instr_debug_test_with_int_debug_trigger_and_ebreak:
+    testname: corev_rand_pulp_instr_debug
+    description: pulp instr random test with random interrupt, debug trigger and debug ebreak
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: gen_rand_int,debug_trigger_basic,debug_ebreak
+
+  corev_rand_pulp_instr_debug_test_with_int_debug_trigger_and_single_step:
+    testname: corev_rand_pulp_instr_debug
+    description: pulp instr random test with random interrupt, debug trigger and single step
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: gen_rand_int,debug_trigger_basic,debug_single_step_en
+
   corev_rand_pulp_hwloop_debug:
     build: uvmt_cv32e40p
     description: hwloop debug random test
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=25000000"
+
+  corev_rand_pulp_hwloop_test_with_random_debug:
+    testname: corev_rand_pulp_hwloop_debug
+    description: hwloop random debug req test
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_test CFG_PLUSARGS="+UVM_TIMEOUT=25000000"
+    test_cfg: gen_rand_debug_req
 
   corev_rand_pulp_hwloop_debug_ebreak:
     testname: corev_rand_pulp_hwloop_debug
@@ -98,6 +202,14 @@ tests:
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=25000000"
     test_cfg: gen_rand_int,debug_trigger_basic
+
+  corev_rand_pulp_hwloop_debug_with_int_debug_ebreak:
+    testname: corev_rand_pulp_hwloop_debug
+    description: hwloop debug with interrupt and debug ebreak random test
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_debug CFG_PLUSARGS="+UVM_TIMEOUT=25000000"
+    test_cfg: gen_rand_int,debug_ebreak
 
   corev_rand_pulp_hwloop_interrupt_test:
     testname: corev_rand_pulp_hwloop_test

--- a/cv32e40p/regress/cv32e40pv2_interrupt_debug_short.yaml
+++ b/cv32e40p/regress/cv32e40pv2_interrupt_debug_short.yaml
@@ -113,7 +113,7 @@ tests:
     build: uvmt_cv32e40p
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=20000000"
-    test_cfg: debug_trigger_basic,gen_rand_debug_req
+    test_cfg: debug_trigger_basic,gen_limit_debug_req
 
   debug_test:
     build: uvmt_cv32e40p

--- a/cv32e40p/sim/ExternalRepos.mk
+++ b/cv32e40p/sim/ExternalRepos.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40p
 CV_CORE_BRANCH ?= dev
-CV_CORE_HASH   ?= d658f650c072bc429ef95aa631dfc186f56b7d4b
+CV_CORE_HASH   ?= c010206894d1f2143ffcfac751bdb2351d08ffdc
 CV_CORE_TAG    ?= none
 
 # The CV_CORE_HASH above points to version of the RTL that is newer.

--- a/cv32e40p/tests/test_cfg/gen_limit_debug_req.yaml
+++ b/cv32e40p/tests/test_cfg/gen_limit_debug_req.yaml
@@ -1,0 +1,5 @@
+name: gen_limit_debug_req
+description: >
+    Generate few random debug halt requests in range 1 to 5, or use plusarg num_debug_req=val to set number 
+plusargs: >
+    +gen_reduced_rand_dbg_req

--- a/cv32e40p/tests/test_cfg/gen_rand_debug_req.yaml
+++ b/cv32e40p/tests/test_cfg/gen_rand_debug_req.yaml
@@ -2,4 +2,4 @@ name: gen_rand_debug_req
 description: >
     Generate Random debug halt request
 plusargs: >
-    +gen_reduced_rand_dbg_req
+    +gen_random_debug


### PR DESCRIPTION
Work done in this PR:

Regression Failure Fixes
- Fix issue for C_SWSP and C_FSWSP in debug rom. Now excluding these from random generation.
- Fix issue of debug_exception handler not defined for debug program and causing state restore logic in debug program to not execute in case of a exception in debug program
- Fix issue of illegal instruction insertion in hwloop body with cv.setupi causing total instructions to exceed 30 and resulting in compilation error from toolchain  

Coverage fixes
- Fix issue for MAC instructions not getting has_rd field set

New Tests for coverage
- Add more debug combinations with random pulp instr stream test
- Add gen_rand_debug_req combination tests for random pulp instr and hwloop tests
- More interrupt combinations with random pulp instr stream test 