### PR TITLE
Cv32e40p/bsm update tb files 0109

### DIFF
--- a/bin/templates/regress_rmdb.j2
+++ b/bin/templates/regress_rmdb.j2
@@ -206,7 +206,7 @@
                 </method>
 {% endif %}
                 <execScript launch="exec" usestderr="no">
-                    <command> echo " TEST RUNCMD: (%t_cmd%) CHECK_SIM_RESULT={{regress_macros.yesorno(check_sim_results)}} COMP=0 CV_CORE={{project}} {{toolchain|upper}}=1 CFG=(%t_cfg%) TEST_CFG_FILE=(%t_test_cfg:%) SIMULATOR=(%t_simulator%) USE_ISS=(%t_iss:%) COV=(%t_cov:%) RUN_INDEX=(%t_iteration%) GEN_START_INDEX=(%t_iteration%) SEED=(%t_iteration%) {{regress_macros.cv_results(results_path)}} {{makeargs}} (%t_makearg%)"</command>
+                    <command> echo " TEST RUNCMD: (%t_cmd%) CHECK_SIM_RESULT={{regress_macros.yesorno(check_sim_results)}} CV_CORE={{project}} {{toolchain|upper}}=1 CFG=(%t_cfg%) TEST_CFG_FILE=(%t_test_cfg:%) SIMULATOR=(%t_simulator%) USE_ISS=(%t_iss:%) COV=(%t_cov:%) RUN_INDEX=(%t_iteration%) GEN_START_INDEX=(%t_iteration%) SEED=(%t_iteration%) {{regress_macros.cv_results(results_path)}} {{makeargs}} (%t_makearg%)"</command>
                     <command> echo "     logfile: (%log_file%)"</command>
                     <command> echo "     RTL repo: CV_CORE_REPO  : ${CV_CORE_REPO}"</command>
                     <command> echo "               CV_CORE_BRANCH: ${CV_CORE_BRANCH}"</command>

--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_float_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_float_instr_lib.sv
@@ -1084,6 +1084,7 @@ class cv32e40p_constraint_mc_fp_instr_stream extends cv32e40p_float_zfinx_base_i
     use_fp_only_for_directed_instr  = 1;
     en_clr_fflags_af_instr          = 0;
     use_same_instr_per_stream       = 1;
+    include_load_store_base_sp      = 1; // store sp is randomly used here
   endfunction: pre_randomize
 
   virtual function void act_post_directed_instr(

--- a/cv32e40p/env/uvme/cov/uvme_rv32x_hwloop_covg.sv
+++ b/cv32e40p/env/uvme/cov/uvme_rv32x_hwloop_covg.sv
@@ -894,6 +894,7 @@ class uvme_rv32x_hwloop_covg # (
           enter_hwloop_sub_cnt++;
           if (is_trap && is_dbg_mode && enter_hwloop_sub_cnt == 1) begin : TRAP_DUETO_DBG_ENTRY // trap cycle and debug are b2b
             is_ebreak = 0; is_ecall = 0; is_illegal = 0; is_trap = 0; enter_hwloop_sub = 0;
+            prev_pc_rdata_main = prev_pc_rdata_main-4;
             for (int j=0; j<HWLOOP_NB; j++) begin
               bit temp_in_nested_loop0 = (j == 0) ? 0 : in_nested_loop0;
               if (hwloop_stat_main.execute_instr_in_hwloop[j] && hwloop_stat_main.track_lp_cnt[j] >= 0 && !temp_in_nested_loop0) begin
@@ -923,6 +924,7 @@ class uvme_rv32x_hwloop_covg # (
           else if (pc_is_mtvec_addr() && is_mcause_irq()) begin : IRQ_ENTRY
             if (hwloop_stat_main.execute_instr_in_hwloop[0] | hwloop_stat_main.execute_instr_in_hwloop[1]) begin
               is_ebreak = 0; is_ecall = 0; is_illegal = 0; is_trap = 0; enter_hwloop_sub = 0;
+              prev_pc_rdata_main = prev_pc_rdata_main-4;
               pending_irq = 0;
               `uvm_info(_header, $sformatf("DEBUG - EXCEPTION Entry is replaced with IRQ Entry (higher priority)"), UVM_DEBUG);
               `IF_CURRENT_IS_MAIN_HWLOOP(0, IS_IRQ)

--- a/cv32e40p/regress/cv32e40pv2_interrupt_debug_short.yaml
+++ b/cv32e40p/regress/cv32e40pv2_interrupt_debug_short.yaml
@@ -149,6 +149,65 @@ tests:
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_instr_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
     test_cfg: gen_rand_int,debug_trigger_basic,debug_single_step_en
 
+# Add corev_rand_fp_instr_debug similar to corev_rand_pulp_instr_debug/test with f/zfinx insn included - START
+
+  corev_rand_fp_instr_debug_test_with_int_and_debug:
+    testname: corev_rand_fp_instr_debug
+    description: fp instr random test with random interrupt and debug trigger
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_fp_instr_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: gen_rand_int,gen_rand_debug_req
+    skip_sim: pulp
+
+  corev_rand_fp_instr_debug_test_with_int_and_debug_trigger:
+    testname: corev_rand_fp_instr_debug
+    description: fp instr random test with random interrupt and debug trigger
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_fp_instr_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: gen_rand_int,debug_trigger_basic,gen_rand_debug_req
+    skip_sim: pulp
+
+  corev_rand_fp_instr_debug_test_with_int_and_debug_single_step:
+    testname: corev_rand_fp_instr_debug
+    description: fp instr random test with random interrupt and debug trigger
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_fp_instr_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: gen_rand_int,debug_single_step_en,gen_rand_debug_req
+    skip_sim: pulp
+
+# note: current fp streams excluding ebreak insn
+#  corev_rand_fp_instr_debug_test_with_int_and_debug_ebreak:
+#    testname: corev_rand_fp_instr_debug
+#    description: pulp instr random test with random interrupt and debug ebreak
+#    build: uvmt_cv32e40p
+#    dir: cv32e40p/sim/uvmt
+#    cmd: make gen_corev-dv test TEST=corev_rand_fp_instr_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+#    test_cfg: gen_rand_int,debug_ebreak,gen_rand_debug_req
+#    skip_sim: pulp
+#
+#  corev_rand_fp_instr_debug_test_with_int_debug_trigger_and_ebreak:
+#    testname: corev_rand_fp_instr_debug
+#    description: pulp instr random test with random interrupt, debug trigger and debug ebreak
+#    build: uvmt_cv32e40p
+#    dir: cv32e40p/sim/uvmt
+#    cmd: make gen_corev-dv test TEST=corev_rand_fp_instr_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+#    test_cfg: gen_rand_int,debug_trigger_basic,debug_ebreak,gen_rand_debug_req
+#    skip_sim: pulp
+
+  corev_rand_fp_instr_debug_test_with_int_debug_trigger_and_single_step:
+    testname: corev_rand_fp_instr_debug
+    description: fp instr random test with random interrupt, debug trigger and single step
+    build: uvmt_cv32e40p
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_fp_instr_debug CFG_PLUSARGS="+UVM_TIMEOUT=10000000"
+    test_cfg: gen_rand_int,debug_trigger_basic,debug_single_step_en,gen_rand_debug_req
+    skip_sim: pulp
+
+# Add corev_rand_fp_instr_debug similar to corev_rand_pulp_instr_debug with f/zfinx insn included - END
+
   corev_rand_pulp_hwloop_debug:
     build: uvmt_cv32e40p
     description: hwloop debug random test

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_imperas_riscv_coverage_config.svh
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_imperas_riscv_coverage_config.svh
@@ -7,7 +7,7 @@
   `define COVER_BASE_RV32I
   `define COVER_LEVEL_COMPL_BAS
   //`define COVER_LEVEL_COMPL_EXT
-  //`define COVER_LEVEL_DV_UP_BAS
+  `define COVER_LEVEL_DV_UP_BAS
   //`define COVER_LEVEL_DV_UP_EXT
   //`define COVER_LEVEL_DV_PR_BAS
   //`define COVER_LEVEL_DV_PR_EXT

--- a/cv32e40p/tests/programs/corev-dv/corev_rand_fp_instr_debug/corev-dv.yaml
+++ b/cv32e40p/tests/programs/corev-dv/corev_rand_fp_instr_debug/corev-dv.yaml
@@ -1,0 +1,38 @@
+# Copyright 2023 Dolphin Design
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+# Test definition YAML for corev-dv test generator
+# corev-dv generator test
+name: corev_rand_fp_instr_debug
+uvm_test: $(CV_CORE_LC)_instr_base_test
+description: >
+    RISCV-DV generated random pulp instr test
+plusargs: >
+    +instr_cnt=1000
+    +num_of_sub_program=0
+    +insert_rand_directed_instr_stream=1
+    +test_rand_directed_instr_stream_num=8
+    +directed_instr_0=cv32e40p_constraint_mc_fp_instr_stream,4
+    +directed_instr_1=cv32e40p_fp_op_fwd_instr_stream,4
+    +directed_instr_2=cv32e40p_fp_op_fwd_instr_w_loadstore_stream,4
+    +rand_directed_instr_0=riscv_load_store_rand_instr_stream,1
+    +rand_directed_instr_1=riscv_load_store_hazard_instr_stream,1
+    +rand_directed_instr_2=riscv_multi_page_load_store_instr_stream,1
+    +rand_directed_instr_3=riscv_jal_instr,1
+    +rand_directed_instr_4=riscv_hazard_instr_stream,1
+    +rand_directed_instr_5=cv32e40p_xpulp_simd_stream_test,1
+    +rand_directed_instr_6=cv32e40p_xpulp_mac_stream_test,1
+    +rand_directed_instr_7=riscv_int_numeric_corner_stream,1
+    +no_fence=0
+    +hint_instr_ratio=2
+    +no_data_page=0
+    +randomize_csr=1
+    +no_branch_jump=1
+    +boot_mode=m
+    +no_csr_instr=0
+    +no_wfi=1
+    +no_dret=1
+    +fix_sp=1
+    +enable_misaligned_instr=1
+    +test_override_riscv_instr_stream=1
+    +test_override_riscv_instr_sequence=1

--- a/cv32e40p/tests/programs/corev-dv/corev_rand_fp_instr_debug/test.yaml
+++ b/cv32e40p/tests/programs/corev-dv/corev_rand_fp_instr_debug/test.yaml
@@ -1,0 +1,10 @@
+# Copyright 2023 Dolphin Design
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+# Test definition YAML for random pulp instr test
+name: corev_rand_fp_instr_debug
+uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
+description: >
+    Random debug in xpulp instruction stream
+plusargs: >
+  #    +gen_reduced_rand_dbg_req


### PR DESCRIPTION
1) modify rmdb template for rerun msg
2) fix hwlp cvgg and fp stream due to corner case issues found in regression
3) enable define for some Imperas extended cp
4) add random fp streams with interrupt and debug events 