### PR TITLE
Added seed option for items in regress generation flow 

### DIFF
--- a/bin/lib/cv_regression.py
+++ b/bin/lib/cv_regression.py
@@ -96,6 +96,11 @@ class Test:
         if not hasattr(self, 'log'):
             self.log = self.name
 
+        if hasattr(self, 'seed'):
+            self.seed_override = 1
+        else:
+            self.seed_override = 0
+
     def set_cov(self):
         '''Set the coverage flag based on app setting.
         If cov already defined (from testlist), then ignore'''

--- a/bin/templates/regress_rmdb.j2
+++ b/bin/templates/regress_rmdb.j2
@@ -61,7 +61,10 @@
     </usertcl>
 
     <usertcl name="seedGen">
-        proc getSeeds { num mode regr_name } {
+        proc getSeeds { num mode regr_name seed_override seed_value } {
+            if { $seed_override == "1" } {
+                return $seed_value
+            }
             if {[string equal $mode "FIXED"]} {
                 return [GetRandomValues $num]
             }
@@ -183,7 +186,7 @@
                     <parameter name="t_test_cfg_name" type="tcl">[getTestCfgName "(%t_test_cfg:%)"]</parameter>
                     <parameter name="t_iss"           type="tcl">[getParameterByPriorityYesOrNo "{{iss}}" "{{t.iss}}" "(%build_iss:%)"]</parameter>
                     <parameter name="t_cov"           type="tcl">[getParameterByPriorityYesOrNo "{{coverage}}" "{{t.cov}}" "(%build_cov:%)"]</parameter>
-                    <parameter name="seeds"           type="tcl">[getSeeds "{{t.num}}" "(%SEED_MODE:RAND%)" "(%reg_name%)"]</parameter>
+                    <parameter name="seeds"           type="tcl">[getSeeds "{{t.num}}" "(%SEED_MODE:RAND%)" "(%reg_name%)" "{{t.seed_override}}" "{{t.seed}}"]</parameter>
                     <parameter name="ucdb_path"       type="tcl">[file join "(%results_sim_path%)" "(%t_cfg%)" "{{t.testname}}" "(%t_test_cfg_name:%)" (%t_iteration%)]</parameter>
                     <parameter name="testname"        type="tcl">[getTestName "{{t.testname}}" "(%t_cfg%)" "(%t_test_cfg_name:%)" (%t_iteration%)]</parameter>
                     <parameter name="ucdb_basename"   type="tcl">[getUCDBFilename "{{t.testname}}" "(%t_test_cfg_name:%)"]</parameter>

--- a/cv32e40p/regress/cv32e40pv2_interrupt_debug.yaml
+++ b/cv32e40p/regress/cv32e40pv2_interrupt_debug.yaml
@@ -109,7 +109,8 @@ tests:
     build: uvmt_cv32e40p
     description: debug_test_boot_set (adapted from v1)
     dir: cv32e40p/sim/uvmt
-    cmd: make test COREV=YES TEST=debug_test_boot_set CFG_PLUSARGS="+UVM_TIMEOUT=20000000" SEED=1 VSIM_USER_FLAGS=+fixed_instr_gnt_stall=10
+    cmd: make test COREV=YES TEST=debug_test_boot_set CFG_PLUSARGS="+UVM_TIMEOUT=20000000" VSIM_USER_FLAGS=+fixed_instr_gnt_stall=10
+    seed: 1
     num: 1
 
   debug_test_known_miscompares:
@@ -291,4 +292,3 @@ tests:
     dir: cv32e40p/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_pulp_hwloop_exception CFG_PLUSARGS="+UVM_TIMEOUT=20000000"
     test_cfg: gen_rand_int,debug_trigger_basic
-

--- a/cv32e40p/regress/cv32e40pv2_interrupt_debug_short.yaml
+++ b/cv32e40p/regress/cv32e40pv2_interrupt_debug_short.yaml
@@ -297,7 +297,8 @@ tests:
     build: uvmt_cv32e40p
     description: debug_test_boot_set (adapted from v1)
     dir: cv32e40p/sim/uvmt
-    cmd: make test COREV=YES TEST=debug_test_boot_set CFG_PLUSARGS="+UVM_TIMEOUT=20000000" SEED=1 VSIM_USER_FLAGS=+fixed_instr_gnt_stall=10
+    cmd: make test COREV=YES TEST=debug_test_boot_set CFG_PLUSARGS="+UVM_TIMEOUT=20000000" VSIM_USER_FLAGS=+fixed_instr_gnt_stall=10
+    seed: 1
     num: 1
 
   debug_test_known_miscompares:


### PR DESCRIPTION
Added a way to specify one unique seed number for a test item in a regress file, and updated a failing test accordingly. 