### PR TITLE
cv32e40p/dev_dd_pgo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,9 @@ transcript
 .opt-rtl
 tools/spike
 tools/verilator*
+VRMDATA
+*fir_q31*
+*float32_division_test*
+*whetstone*
+*.do
+*eembc*

--- a/cv32e40p/bsp/link_gp_relax.ld
+++ b/cv32e40p/bsp/link_gp_relax.ld
@@ -242,23 +242,8 @@ SECTIONS
   . = SEGMENT_START("ldata-segment", .);
   . = ALIGN(32 / 8);
   __bss_end = .;
-  /* In toolchain, x3 is the gp global pointer register and gp relaxation occurs.
-     When GP relaxation is enabled, gp should be initialized at startup to __global_pointer$ and
-     the rest of the code should not modify gp.
-     If you want to disable GP relaxation, then set __global_pointer$ to linker file or remove it completely.
-     In corev-dv random generator test, gp (x3) is used as any register and can be written many times.
-     And it is using la pseudo-instruction which is replaced by auipc/addi which can be gp relaxed,
-     meaning auipc will be omitted after being executed once in crt0.S. Then final binary is not functional.
-
-     https://github.com/openhwgroup/corev-gcc/issues/92
-
-     Following lines will be kept in a new linker file (link_gp_relax.ld) used for benchmarks and applications
-     as gp relaxation generally improves code size and performances.
-
     __global_pointer$ = MIN(__SDATA_BEGIN__ + 0x800,
 		            MAX(__DATA_BEGIN__ + 0x800, __bss_end - 0x800));
-  */
-  __global_pointer$ = 0;
   _end = .; PROVIDE (end = .);
   . = DATA_SEGMENT_END (.);
 

--- a/cv32e40p/tests/cfg/pulp.yaml
+++ b/cv32e40p/tests/cfg/pulp.yaml
@@ -12,6 +12,7 @@ ovpsim: >
     --override cpu/extension_CVE4P/CORE_VERSION=2
     --override cpu/extension_CVE4P/COREV_PULP=T
     --override cpu/extension_CVE4P/COREV_CLUSTER=F
+    --override cpu/extension_CVE4P/hwloop_severity=Warning
     --override cpu/add_Extensions=X
     -showinstanceparams cpu
 # Debug options (add to ovpsim section as needed)

--- a/cv32e40p/tests/cfg/pulp_cluster.yaml
+++ b/cv32e40p/tests/cfg/pulp_cluster.yaml
@@ -12,6 +12,7 @@ ovpsim: >
     --override cpu/extension_CVE4P/CORE_VERSION=2
     --override cpu/extension_CVE4P/COREV_PULP=T
     --override cpu/extension_CVE4P/COREV_CLUSTER=T
+    --override cpu/extension_CVE4P/hwloop_severity=Warning
     --override cpu/add_Extensions=X
     -showinstanceparams cpu
 # Debug options (add to ovpsim section as needed)

--- a/cv32e40p/tests/cfg/pulp_cluster_fpu.yaml
+++ b/cv32e40p/tests/cfg/pulp_cluster_fpu.yaml
@@ -12,6 +12,7 @@ ovpsim: >
     --override cpu/extension_CVE4P/CORE_VERSION=2
     --override cpu/extension_CVE4P/COREV_PULP=T
     --override cpu/extension_CVE4P/COREV_CLUSTER=T
+    --override cpu/extension_CVE4P/hwloop_severity=Warning
     --override cpu/add_Extensions=XF
     --override cpu/Zcf=T
     -showinstanceparams cpu

--- a/cv32e40p/tests/cfg/pulp_cluster_fpu_1cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_cluster_fpu_1cyclat.yaml
@@ -12,6 +12,7 @@ ovpsim: >
     --override cpu/extension_CVE4P/CORE_VERSION=2
     --override cpu/extension_CVE4P/COREV_PULP=T
     --override cpu/extension_CVE4P/COREV_CLUSTER=T
+    --override cpu/extension_CVE4P/hwloop_severity=Warning
     --override cpu/add_Extensions=XF
     --override cpu/Zcf=T
     -showinstanceparams cpu

--- a/cv32e40p/tests/cfg/pulp_cluster_fpu_2cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_cluster_fpu_2cyclat.yaml
@@ -12,6 +12,7 @@ ovpsim: >
     --override cpu/extension_CVE4P/CORE_VERSION=2
     --override cpu/extension_CVE4P/COREV_PULP=T
     --override cpu/extension_CVE4P/COREV_CLUSTER=T
+    --override cpu/extension_CVE4P/hwloop_severity=Warning
     --override cpu/add_Extensions=XF
     --override cpu/Zcf=T
     -showinstanceparams cpu

--- a/cv32e40p/tests/cfg/pulp_cluster_fpu_zfinx.yaml
+++ b/cv32e40p/tests/cfg/pulp_cluster_fpu_zfinx.yaml
@@ -12,6 +12,7 @@ ovpsim: >
     --override cpu/extension_CVE4P/CORE_VERSION=2
     --override cpu/extension_CVE4P/COREV_PULP=T
     --override cpu/extension_CVE4P/COREV_CLUSTER=T
+    --override cpu/extension_CVE4P/hwloop_severity=Warning
     --override cpu/add_Extensions=XF
     --override cpu/Zcf=T
     --override cpu/Zfinx_version=0.41

--- a/cv32e40p/tests/cfg/pulp_cluster_fpu_zfinx_1cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_cluster_fpu_zfinx_1cyclat.yaml
@@ -12,6 +12,7 @@ ovpsim: >
     --override cpu/extension_CVE4P/CORE_VERSION=2
     --override cpu/extension_CVE4P/COREV_PULP=T
     --override cpu/extension_CVE4P/COREV_CLUSTER=T
+    --override cpu/extension_CVE4P/hwloop_severity=Warning
     --override cpu/add_Extensions=XF
     --override cpu/Zcf=T
     --override cpu/Zfinx_version=0.41

--- a/cv32e40p/tests/cfg/pulp_cluster_fpu_zfinx_2cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_cluster_fpu_zfinx_2cyclat.yaml
@@ -12,6 +12,7 @@ ovpsim: >
     --override cpu/extension_CVE4P/CORE_VERSION=2
     --override cpu/extension_CVE4P/COREV_PULP=T
     --override cpu/extension_CVE4P/COREV_CLUSTER=T
+    --override cpu/extension_CVE4P/hwloop_severity=Warning
     --override cpu/add_Extensions=XF
     --override cpu/Zcf=T
     --override cpu/Zfinx_version=0.41

--- a/cv32e40p/tests/cfg/pulp_fpu.yaml
+++ b/cv32e40p/tests/cfg/pulp_fpu.yaml
@@ -12,6 +12,7 @@ ovpsim: >
     --override cpu/extension_CVE4P/CORE_VERSION=2
     --override cpu/extension_CVE4P/COREV_PULP=T
     --override cpu/extension_CVE4P/COREV_CLUSTER=F
+    --override cpu/extension_CVE4P/hwloop_severity=Warning
     --override cpu/add_Extensions=XF
     --override cpu/Zcf=T
     -showinstanceparams cpu

--- a/cv32e40p/tests/cfg/pulp_fpu_1cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_fpu_1cyclat.yaml
@@ -12,6 +12,7 @@ ovpsim: >
     --override cpu/extension_CVE4P/CORE_VERSION=2
     --override cpu/extension_CVE4P/COREV_PULP=T
     --override cpu/extension_CVE4P/COREV_CLUSTER=F
+    --override cpu/extension_CVE4P/hwloop_severity=Warning
     --override cpu/add_Extensions=XF
     --override cpu/Zcf=T
     -showinstanceparams cpu

--- a/cv32e40p/tests/cfg/pulp_fpu_2cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_fpu_2cyclat.yaml
@@ -12,6 +12,7 @@ ovpsim: >
     --override cpu/extension_CVE4P/CORE_VERSION=2
     --override cpu/extension_CVE4P/COREV_PULP=T
     --override cpu/extension_CVE4P/COREV_CLUSTER=F
+    --override cpu/extension_CVE4P/hwloop_severity=Warning
     --override cpu/add_Extensions=XF
     --override cpu/Zcf=T
     -showinstanceparams cpu

--- a/cv32e40p/tests/cfg/pulp_fpu_zfinx.yaml
+++ b/cv32e40p/tests/cfg/pulp_fpu_zfinx.yaml
@@ -12,6 +12,7 @@ ovpsim: >
     --override cpu/extension_CVE4P/CORE_VERSION=2
     --override cpu/extension_CVE4P/COREV_PULP=T
     --override cpu/extension_CVE4P/COREV_CLUSTER=F
+    --override cpu/extension_CVE4P/hwloop_severity=Warning
     --override cpu/add_Extensions=XF
     --override cpu/Zcf=T
     --override cpu/Zfinx_version=0.41

--- a/cv32e40p/tests/cfg/pulp_fpu_zfinx_1cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_fpu_zfinx_1cyclat.yaml
@@ -12,6 +12,7 @@ ovpsim: >
     --override cpu/extension_CVE4P/CORE_VERSION=2
     --override cpu/extension_CVE4P/COREV_PULP=T
     --override cpu/extension_CVE4P/COREV_CLUSTER=F
+    --override cpu/extension_CVE4P/hwloop_severity=Warning
     --override cpu/add_Extensions=XF
     --override cpu/Zcf=T
     --override cpu/Zfinx_version=0.41

--- a/cv32e40p/tests/cfg/pulp_fpu_zfinx_2cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_fpu_zfinx_2cyclat.yaml
@@ -12,6 +12,7 @@ ovpsim: >
     --override cpu/extension_CVE4P/CORE_VERSION=2
     --override cpu/extension_CVE4P/COREV_PULP=T
     --override cpu/extension_CVE4P/COREV_CLUSTER=F
+    --override cpu/extension_CVE4P/hwloop_severity=Warning
     --override cpu/add_Extensions=XF
     --override cpu/Zcf=T
     --override cpu/Zfinx_version=0.41

--- a/cv32e40p/tests/programs/custom/coremark/link.ld
+++ b/cv32e40p/tests/programs/custom/coremark/link.ld
@@ -1,0 +1,1 @@
+../../../../bsp/link_gp_relax.ld

--- a/cv32e40p/tests/programs/custom/dhrystone/link.ld
+++ b/cv32e40p/tests/programs/custom/dhrystone/link.ld
@@ -1,0 +1,1 @@
+../../../../bsp/link_gp_relax.ld

--- a/cv32e40p/tests/programs/custom/fibonacci/link.ld
+++ b/cv32e40p/tests/programs/custom/fibonacci/link.ld
@@ -1,0 +1,1 @@
+../../../../bsp/link_gp_relax.ld

--- a/cv32e40p/tests/programs/custom/matmul_32b_float/link.ld
+++ b/cv32e40p/tests/programs/custom/matmul_32b_float/link.ld
@@ -1,0 +1,1 @@
+../../../../bsp/link_gp_relax.ld

--- a/cv32e40p/tests/programs/custom/matmul_32b_int/link.ld
+++ b/cv32e40p/tests/programs/custom/matmul_32b_int/link.ld
@@ -1,0 +1,1 @@
+../../../../bsp/link_gp_relax.ld


### PR DESCRIPTION
- New linker script to resolve gp relaxation (gcc issue [#92](https://github.com/openhwgroup/corev-gcc/issues/92)).
- Added Imperas model HWloop constraints check severity variable.