### PR TITLE
cv_regress fixes & tests update

### DIFF
--- a/bin/cv_regress
+++ b/bin/cv_regress
@@ -200,8 +200,23 @@ def read_file(args, file, f_idx=0):
                 continue
         except KeyError:
             pass
+        except AttributeError as ex:
+            # no simulator or cfg in test Object, need to check build parameter, and remove the build
+            # from test build list before adding the test to the regress list
+            if ex.args[0].find('cfg') > 0:
+                new_list_of_builds = [b for b in test.builds if regression.builds[b].cfg not in t['skip_sim']]
+                logger.info('Regression: builds {} have been removed for test {} due to cfg skipped'.format([b for b in test.builds if b not in new_list_of_builds], test.name))
+                test.builds = new_list_of_builds
+
+        if not test.builds:
+            logger.warning('Regression: Test {} has no build and will be skipped'.format(test.name))
+            continue
 
         regression.add_test(test)
+
+    if not regression.tests:
+            logger.fatal('Regression: No test in the regression {}'.format(regression.name))
+            os.sys.exit(2)
 
     return regression
 

--- a/bin/cv_regress
+++ b/bin/cv_regress
@@ -184,12 +184,6 @@ def read_file(args, file, f_idx=0):
                     test.num = int(args.num[0])
             else:
                 test.num = 1
-        elif test.num != 1:
-            if args.num:
-                try:
-                    test.num = int(args.num[f_idx])
-                except IndexError:
-                    test.num = int(args.num[0])
 
         try:
             if test.simulator in t['skip_sim']:

--- a/cv32e40p/tests/programs/custom/modeled_csr_por/modeled_csr_por.c
+++ b/cv32e40p/tests/programs/custom/modeled_csr_por/modeled_csr_por.c
@@ -1,19 +1,19 @@
 /*
 **
 ** Copyright 2020 OpenHW Group
-** 
+**
 ** Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
 ** You may obtain a copy of the License at
-** 
+**
 **     https://solderpad.org/licenses/
-** 
+**
 ** Unless required by applicable law or agreed to in writing, software
 ** distributed under the License is distributed on an "AS IS" BASIS,
 ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ** See the License for the specific language governing permissions and
 ** limitations under the License.
-** 
+**
 *******************************************************************************
 **
 ** Modeled CSR power-on-reset test:
@@ -35,7 +35,7 @@
 
 #ifdef NO_PULP
 #define EXP_MISA 0x40001104
-#else 
+#else
 #define EXP_MISA 0x40801104
 #endif
 
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
   __asm__ volatile("csrr %0, 0x7C4" : "=r"(lpstart1_rval));
   __asm__ volatile("csrr %0, 0x7C5" : "=r"(lpend1_rval));
   __asm__ volatile("csrr %0, 0x7C6" : "=r"(lpcount1_rval));
- 
+
   if (lpstart0_rval != 0x0) {
     printf("ERROR: CSR LPSTART0 not zero!\n\n");
     ++err_cnt;
@@ -162,7 +162,7 @@ int main(int argc, char *argv[])
   }
 
 	//__asm__ volatile("csrr %0, 0x306" : "=r"(mcounteren_rval));    // Not currently modeled
-  //__asm__ volatile("csrr %0, 0x320" : "=r"(mcountinhibit_rval)); // Modeled, but cannot override PoR 
+  //__asm__ volatile("csrr %0, 0x320" : "=r"(mcountinhibit_rval)); // Modeled, but cannot override PoR
 
   //if (mcounteren_rval != 0x0) {
   //  printf("ERROR: CSR MCOUNTEREN not 0x0!\n\n");
@@ -450,7 +450,11 @@ int main(int argc, char *argv[])
     ++err_cnt;
   }
 
+#if defined(FPU) || defined(PULP) || defined(CLUSTER)
+  if (mimpid_rval != 0x1) {
+#else
   if (mimpid_rval != 0x0) {
+#endif
     printf("ERROR: CSR MIMPLID not zero!\n\n");
     ++err_cnt;
   }

--- a/cv32e40p/tests/programs/custom/requested_csr_por/requested_csr_por.c
+++ b/cv32e40p/tests/programs/custom/requested_csr_por/requested_csr_por.c
@@ -1,19 +1,19 @@
 /*
 **
 ** Copyright 2020 OpenHW Group
-** 
+**
 ** Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
 ** You may obtain a copy of the License at
-** 
+**
 **     https://solderpad.org/licenses/
-** 
+**
 ** Unless required by applicable law or agreed to in writing, software
 ** distributed under the License is distributed on an "AS IS" BASIS,
 ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ** See the License for the specific language governing permissions and
 ** limitations under the License.
-** 
+**
 *******************************************************************************
 **
 ** CSR power-on-reset test:   Reads the CSRs and prints some useful (?)
@@ -33,7 +33,7 @@
 
 #ifdef NO_PULP
 #define EXP_MISA 0x40001104
-#else 
+#else
 #define EXP_MISA 0x40801104
 #endif
 
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
   __asm__ volatile("csrr %0, 0x7C6" : "=r"(lpcount1_rval));
   __asm__ volatile("csrr %0, 0xC10" : "=r"(privlv_rval));
   __asm__ volatile("csrr %0, 0x014" : "=r"(uhartid_rval));
- 
+
   if (lpstart0_rval != 0x0) {
     printf("ERROR: CSR LPSTART0 not zero!\n\n");
     ++err_cnt;
@@ -400,7 +400,12 @@ int main(int argc, char *argv[])
     ++err_cnt;
   }
 
+
+#if defined(FPU) || defined(PULP) || defined(CLUSTER)
+  if (mimpid_rval != 0x1) {
+#else
   if (mimpid_rval != 0x0) {
+#endif
     printf("ERROR: CSR MIMPLID not zero!\n\n");
     ++err_cnt;
   }
@@ -416,7 +421,7 @@ int main(int argc, char *argv[])
     printf("ERROR: CSR MCOUNTINHIBIT not 0xD!\n\n");
     ++err_cnt;
   }
- 
+
   //__asm__ volatile("csrr %0, 0x306" : "=r"(mcounteren_rval));    // Not currently modeled
 
   //if (mcounteren_rval != 0x0) {


### PR DESCRIPTION
- Corrected two v1 tests to be compatible with v2 spec (mimpid field is not 0 if FPU, PULP or CLUSTER are defined) 
- Corrected a bug in cv_regress script if a cfg is in `skip_sim` list, but test item has no cfg either inside the YAML `file or no cfg is given by the cmd switch `--cfg`
- Simplified behaviour of `num` field for tests the YAML list has always the priority versus the cmd switch `--num` (Before, it was the case only if num == 1) 