### PR TITLE
Enable cp_last_fpu_apu_op_at_contention for fpu latency 0 and 2; Add …

### DIFF
--- a/cv32e40p/env/uvme/cov/uvme_cv32e40p_zfinx_instr_covg.sv
+++ b/cv32e40p/env/uvme/cov/uvme_cv32e40p_zfinx_instr_covg.sv
@@ -55,11 +55,20 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
      ignore_bins in_contention_lsu_wr = ( binsof(cp_apu_contention) intersect {1} ) \
                                         with ( ((cp_curr_fpu_apu_op + 1) * (fpu_latency == 1)) != 0 );
 
+    `define IGNORE_BINS_PREV_NON_FPU_OPCODE_WO_RD \
+     ignore_bins prev_non_fpu_wo_rd = !binsof(cp_prev_is_non_fpu_opcode) intersect {`RV32_OPCODE_LIST1_WITH_RD};
+
+    `define IGNORE_BINS_CUR_FPU_OPCODE_WO_RS2 \
+     ignore_bins cur_fpu_wo_rs2 = !binsof(cp_cur_is_fpu_instr) intersect {`RV32ZFINX_INSTR_W_RS2};
+
+    `define IGNORE_BINS_CUR_FPU_OPCODE_WO_RS3 \
+     ignore_bins cur_fpu_wo_rs3 = !binsof(cp_cur_is_fpu_instr) intersect {`RV32ZFINX_INSTR_W_RS3};
+
     `define IGNORE_BINS_NON_RS1_CV32E40P_INSTR \
      ignore_bins non_rs1_rv32_instr = binsof(cp_id_stage_non_rv32fc_inst) intersect {TB_OPCODE_LUI,TB_OPCODE_AUIPC,TB_OPCODE_JAL};
 
     `define IGNORE_BINS_NON_RS2_CV32E40P_INSTR \
-     ignore_bins non_rs2_rv32_instr = binsof(cp_id_stage_non_rv32fc_inst) intersect {`RV32_INSTR_WITH_NO_RS2};
+     ignore_bins non_rs2_rv32_instr = binsof(cp_id_stage_non_rv32fc_inst) intersect {`RV32_OPCODE_WITH_NO_RS2};
 
     `define IGNORE_BINS_NON_STALLED_CONTENTION_WR_STATE \
      ignore_bins non_stalled_contention_wr_state = binsof(cp_contention_state) intersect {0,1};
@@ -71,10 +80,10 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
      ignore_bins no_contention = binsof(cp_apu_contention) intersect {1};
 
     `define IGNORE_BINS_NON_RS2_ZFINX_INSTR \
-     ignore_bins non_rs2_f_inst = !binsof(cp_id_stage_f_inst) intersect {`RV32F_INSTR_WITH_FS2};
+     ignore_bins non_rs2_f_inst = !binsof(cp_id_stage_f_inst) intersect {`RV32ZFINX_INSTR_W_RS2};
 
     `define IGNORE_BINS_NON_RS3_ZFINX_INSTR \
-     ignore_bins non_rs3_f_inst = !binsof(cp_id_stage_f_inst) intersect {`RV32F_INSTR_WITH_FS3};
+     ignore_bins non_rs3_f_inst = !binsof(cp_id_stage_f_inst) intersect {`RV32ZFINX_INSTR_W_RS3};
 
     `define IGNORE_BINS_NO_CONTENTION_LSU \
      ignore_bins no_contention_lsu_wr = binsof(cp_apu_contention) intersect {0};
@@ -102,6 +111,7 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
             option.weight = 5;
         }
 
+        // from bhv_logic_1
         cp_f_multicycle_clk_window : coverpoint cntxt.cov_vif.if_clk_cycle_window iff ((`COVIF_CB.is_mulh_ex == 0) &&
                                                                                        (`COVIF_CB.is_misaligned_data_req_ex == 0) &&
                                                                                        (`COVIF_CB.is_post_inc_ld_st_inst_ex == 0) &&
@@ -154,11 +164,13 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
             bins apu_busy_high = {1'b1};
         }
 
+        // from bhv_logic_1
         cp_curr_fpu_apu_op : coverpoint cntxt.cov_vif.o_curr_fpu_apu_op_if {
             `ZFINX_OP_BINS
             option.weight = 5;
         }
 
+        // from bhv_logic_1
         cp_curr_fpu_apu_op_at_apu_req : coverpoint cntxt.cov_vif.o_curr_fpu_apu_op_if iff ( (`COVIF_CB.apu_req == 1) &&
                                                                                             (`COVIF_CB.apu_gnt == 1) )
         {
@@ -166,6 +178,7 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
             option.weight = 5;
         }
 
+        // from bhv_logic_1
         cp_curr_fpu_apu_op_multicycle : coverpoint cntxt.cov_vif.o_curr_fpu_apu_op_if iff (`COVIF_CB.apu_busy == 1)
         {
             `ZFINX_OP_BINS
@@ -288,31 +301,61 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
             bins has_contention = {1};
         }
 
+        // from bhv_logic_1
         cp_curr_fpu_apu_op : coverpoint cntxt.cov_vif.o_curr_fpu_apu_op_if {
             `ZFINX_OP_BINS
             option.weight = 5;
         }
 
+        // from bhv_logic_1a
+        // all instr in zfinx with rs1/2/3
+        cp_cur_fp_rs1_match_prev_nonfp_rd : coverpoint (cntxt.cov_vif.current_instr_rdata[19:15] == cntxt.cov_vif.previous_instr_rdata[11:7])
+          iff (cntxt.cov_vif.previous_instr_rdata[6:0] inside {`RV32_OPCODE_LIST1_WITH_RD} &&
+               cntxt.cov_vif.current_instr_rdata != cntxt.cov_vif.previous_instr_rdata) {
+          bins cur_rs1_match_prev_rd = {1};
+        }
+        cp_cur_fp_rs2_match_prev_nonfp_rd : coverpoint (cntxt.cov_vif.current_instr_rdata[24:20] == cntxt.cov_vif.previous_instr_rdata[11:7])
+          iff (cntxt.cov_vif.current_instr_rdata       inside {`RV32ZFINX_INSTR_W_RS2} && 
+               cntxt.cov_vif.previous_instr_rdata[6:0] inside {`RV32_OPCODE_LIST1_WITH_RD} &&
+               cntxt.cov_vif.current_instr_rdata != cntxt.cov_vif.previous_instr_rdata) {
+          bins cur_rs2_match_prev_rd = {1};
+        }
+        cp_cur_fp_rs3_match_prev_nonfp_rd : coverpoint (cntxt.cov_vif.current_instr_rdata[31:27] == cntxt.cov_vif.previous_instr_rdata[11:7])
+          iff (cntxt.cov_vif.current_instr_rdata       inside {`RV32ZFINX_INSTR_W_RS3} && 
+               cntxt.cov_vif.previous_instr_rdata[6:0] inside {`RV32_OPCODE_LIST1_WITH_RD} &&
+               cntxt.cov_vif.current_instr_rdata != cntxt.cov_vif.previous_instr_rdata) {
+          bins cur_rs3_match_prev_rd = {1};
+        }
+        cp_cur_is_fpu_instr : coverpoint cntxt.cov_vif.current_instr_rdata {
+          `ZFINX_INSTR_BINS
+        }
+        cp_prev_is_non_fpu_opcode : coverpoint cntxt.cov_vif.previous_instr_rdata[6:0] {
+          `CV32E40P_INSTR_OPCODE_BIT_6_0_BINS__NO_RV32C_FC_F
+        }
+        cp_prev_is_non_fpu_rd : coverpoint cntxt.cov_vif.previous_instr_rdata[11:7] {
+          bins rd[] = {[0:31]};
+        }
+
+        // from bhv_logic_2
         cp_last_fpu_apu_op_at_contention : coverpoint cntxt.cov_vif.o_last_fpu_apu_op_if {
-            bins curr_apu_op_fmadd        =    {APU_OP_FMADD}       with ( ((item + 1) * (fpu_latency == 1)) != 0 );
-            bins curr_apu_op_fnmsub       =    {APU_OP_FNMSUB}      with ( ((item + 1) * (fpu_latency == 1)) != 0 );
-            bins curr_apu_op_fadd         =    {APU_OP_FADD}        with ( ((item + 1) * (fpu_latency == 1)) != 0 );
-            bins curr_apu_op_fmul         =    {APU_OP_FMUL}        with ( ((item + 1) * (fpu_latency == 1)) != 0 );
-            bins curr_apu_op_fdiv         =    {APU_OP_FDIV}        with ( ((item + 1) * (fpu_latency == 1)) != 0 );
-            bins curr_apu_op_fsqrt        =    {APU_OP_FSQRT}       with ( ((item + 1) * (fpu_latency == 1)) != 0 );
-            bins curr_apu_op_fsgnj        =    {APU_OP_FSGNJ}       with ( ((item + 1) * (fpu_latency == 1)) != 0 );
-            bins curr_apu_op_fminmax      =    {APU_OP_FMINMAX}     with ( ((item + 1) * (fpu_latency == 1)) != 0 );
-            bins curr_apu_op_fcmp         =    {APU_OP_FCMP}        with ( ((item + 1) * (fpu_latency == 1)) != 0 );
-            bins curr_apu_op_fclassify    =    {APU_OP_FCLASSIFY}   with ( ((item + 1) * (fpu_latency == 1)) != 0 );
-            bins curr_apu_op_f2f          =    {APU_OP_F2F}         with ( ((item + 1) * (fpu_latency == 1)) != 0 );
-            bins curr_apu_op_f2i          =    {APU_OP_F2I}         with ( ((item + 1) * (fpu_latency == 1)) != 0 );
-            bins curr_apu_op_i2f          =    {APU_OP_I2F}         with ( ((item + 1) * (fpu_latency == 1)) != 0 );
-            bins curr_apu_op_fmsub        =    {APU_OP_FMSUB}       with ( ((item + 1) * (fpu_latency == 1)) != 0 );
-            bins curr_apu_op_fnmadd       =    {APU_OP_FNMADD}      with ( ((item + 1) * (fpu_latency == 1)) != 0 );
-            bins curr_apu_op_fsub         =    {APU_OP_FSUB}        with ( ((item + 1) * (fpu_latency == 1)) != 0 );
-            bins curr_apu_op_fsgnj_se     =    {APU_OP_FSGNJ_SE}    with ( ((item + 1) * (fpu_latency == 1)) != 0 );
-            bins curr_apu_op_f2i_u        =    {APU_OP_F2I_U}       with ( ((item + 1) * (fpu_latency == 1)) != 0 );
-            bins curr_apu_op_i2f_u        =    {APU_OP_I2F_U}       with ( ((item + 1) * (fpu_latency == 1)) != 0 );
+            bins curr_apu_op_fmadd        =    {APU_OP_FMADD}     with (fpu_latency != 0);
+            bins curr_apu_op_fnmsub       =    {APU_OP_FNMSUB}    with (fpu_latency != 0);
+            bins curr_apu_op_fadd         =    {APU_OP_FADD}      with (fpu_latency != 0);
+            bins curr_apu_op_fmul         =    {APU_OP_FMUL}      with (fpu_latency != 0);
+            bins curr_apu_op_fdiv         =    {APU_OP_FDIV}      ;
+            bins curr_apu_op_fsqrt        =    {APU_OP_FSQRT}     ;
+            bins curr_apu_op_fsgnj        =    {APU_OP_FSGNJ}     with (fpu_latency != 0);
+            bins curr_apu_op_fminmax      =    {APU_OP_FMINMAX}   with (fpu_latency != 0);
+            bins curr_apu_op_fcmp         =    {APU_OP_FCMP}      with (fpu_latency != 0);
+            bins curr_apu_op_fclassify    =    {APU_OP_FCLASSIFY} with (fpu_latency != 0);
+            bins curr_apu_op_f2i          =    {APU_OP_F2I}       with (fpu_latency != 0);
+            bins curr_apu_op_i2f          =    {APU_OP_I2F}       with (fpu_latency != 0);
+            bins curr_apu_op_fmsub        =    {APU_OP_FMSUB}     with (fpu_latency != 0);
+            bins curr_apu_op_fnmadd       =    {APU_OP_FNMADD}    with (fpu_latency != 0);
+            bins curr_apu_op_fsub         =    {APU_OP_FSUB}      with (fpu_latency != 0);
+            bins curr_apu_op_fsgnj_se     =    {APU_OP_FSGNJ_SE}  with (fpu_latency != 0);
+            bins curr_apu_op_f2i_u        =    {APU_OP_F2I_U}     with (fpu_latency != 0);
+            bins curr_apu_op_i2f_u        =    {APU_OP_I2F_U}     with (fpu_latency != 0);
             option.weight = 5;
         }
 
@@ -344,14 +387,17 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
             bins fs2[] = {[0:31]};
         }
 
+        // from bhv_logic_3
         cp_curr_fpu_inst_fd : coverpoint cntxt.cov_vif.curr_fpu_fd {
             bins fd[] = {[0:31]};
         }
 
+        // from bhv_logic_3
         cp_curr_fpu_inst_rd : coverpoint cntxt.cov_vif.curr_fpu_rd {
             bins rd[] = {[0:31]};
         }
 
+        // from bhv_logic_3
         cp_curr_fpu_inst_rd_for_0_lat_apu_result : coverpoint cntxt.cov_vif.curr_fpu_rd
                                                               iff ( (`COVIF_CB.apu_req == 1) && 
                                                                     (`COVIF_CB.apu_gnt == 1) &&         
@@ -359,6 +405,7 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
             bins rd[] = {[0:31]} with (fpu_latency == 0);
         }
 
+        // from bhv_logic_3
         cp_curr_fpu_inst_rd_for_multicyc_lat_apu_result : coverpoint cntxt.cov_vif.curr_fpu_rd
                                                                      iff ( (`COVIF_CB.apu_busy == 1) && 
                                                                            (`COVIF_CB.apu_rvalid_i == 1) ) {
@@ -371,11 +418,14 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
             illegal_bins rd_addr_32_63 = {[32:63]};
         }
 
+        // from bhv_logic_3
         cp_lsu_apu_contention_wr_rd : coverpoint cntxt.cov_vif.curr_rd_at_wb_regfile_wr_contention {
             bins rd[] = {[0:31]} with ( (item < 32) & (fpu_latency == 1) );
             illegal_bins rd_addr_32_63 = {[32:63]};
         }
 
+        // from bhv_logic_2 (revised)
+        // [optional] this cp is optional as contention has no relation with rd/fd
         cp_prev_rd_waddr_contention : coverpoint cntxt.cov_vif.prev_rd_waddr_contention {
             bins rd[] = {[0:31]};
             illegal_bins rd_addr_32_63 = {[32:63]};  //for zfinx only 32 gprs available
@@ -393,18 +443,24 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
             bins b2b_contention_true = {1};
         }
 
+        // from bhv_logic_3
+        // next fp_insn rs1 is rd of current fp_insn
         cp_rd_rs1_eq : coverpoint (`COVIF_CB.id_stage_instr_rdata_i[19:15] == cntxt.cov_vif.curr_fpu_rd)
                                   iff (`COVIF_CB.id_stage_instr_valid_i == 1) {
 
             bins rd_rs1_equal = {1};
         }
 
+        // from bhv_logic_3
+        // next fp_insn rs2 is rd of current fp_insn
         cp_rd_rs2_eq : coverpoint (`COVIF_CB.id_stage_instr_rdata_i[24:20] == cntxt.cov_vif.curr_fpu_rd)
                                   iff (`COVIF_CB.id_stage_instr_valid_i == 1) {
 
             bins rd_rs2_equal = {1};
         }
 
+        // from bhv_logic_3
+        // next fp_insn rs3 is rd of current fp_insn
         cp_rd_rs3_eq : coverpoint (`COVIF_CB.id_stage_instr_rdata_i[31:27] == cntxt.cov_vif.curr_fpu_rd)
                                   iff (`COVIF_CB.id_stage_instr_valid_i == 1) {
 
@@ -481,6 +537,37 @@ class uvme_cv32e40p_zfinx_instr_covg extends uvm_component;
             `IGNORE_BINS_ZERO_LAT_FPU_OP
             `IGNORE_BINS_NON_RS1_CV32E40P_INSTR
             `IGNORE_BINS_NON_RS2_CV32E40P_INSTR
+        }
+
+        // cross coverage for F-instr following Non F-instr with rd to rs dependency
+        // e.g prev.non_fp(rd) == cur.fp(rs1/2/3)
+        cr_non_rv32f_rd_rv32f_rs1                : cross cp_cur_fp_rs1_match_prev_nonfp_rd,
+                                                         cp_cur_is_fpu_instr,
+                                                         cp_prev_is_non_fpu_opcode,
+                                                         cp_prev_is_non_fpu_rd {
+
+            option.weight = 5;
+            // e.g bin that ignore combination of cur and prev instr (this can reduce cross bins number drastically)
+            // bins op_fwd_xreg0 = binsof(cp_prev_is_non_fpu_rd) intersect {0} && binsof(cp_cur_fp_rs1_match_prev_nonfp_rd);
+            `IGNORE_BINS_PREV_NON_FPU_OPCODE_WO_RD
+        }
+        cr_non_rv32f_rd_rv32f_rs2                : cross cp_cur_fp_rs2_match_prev_nonfp_rd,
+                                                         cp_cur_is_fpu_instr,
+                                                         cp_prev_is_non_fpu_opcode,
+                                                         cp_prev_is_non_fpu_rd {
+
+            option.weight = 5;
+            `IGNORE_BINS_PREV_NON_FPU_OPCODE_WO_RD
+            `IGNORE_BINS_CUR_FPU_OPCODE_WO_RS2
+        }
+        cr_non_rv32f_rd_rv32f_rs3                : cross cp_cur_fp_rs3_match_prev_nonfp_rd,
+                                                         cp_cur_is_fpu_instr,
+                                                         cp_prev_is_non_fpu_opcode,
+                                                         cp_prev_is_non_fpu_rd {
+
+            option.weight = 5;
+            `IGNORE_BINS_PREV_NON_FPU_OPCODE_WO_RD
+            `IGNORE_BINS_CUR_FPU_OPCODE_WO_RS3
         }
 
         // cross coverage for contention case 2nd cycle with ALU regfile write

--- a/cv32e40p/env/uvme/uvme_cv32e40p_macros.sv
+++ b/cv32e40p/env/uvme/uvme_cv32e40p_macros.sv
@@ -27,8 +27,13 @@
 `define APU_INSTR_WITH_NO_FD \
  APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U
 
-`define RV32_INSTR_WITH_NO_RS2 \
- TB_OPCODE_LUI,TB_OPCODE_AUIPC,TB_OPCODE_JAL,TB_OPCODE_JALR,TB_OPCODE_LOAD,TB_OPCODE_OPIMM,TB_OPCODE_FENCE,TB_OPCODE_SYSTEM
+ // LIST1 is CV32E40P_INSTR_OPCODE_BIT_6_0_BINS__NO_RV32C_FC_F
+`define RV32_OPCODE_LIST1_WITH_RD \
+  TB_OPCODE_OP, TB_OPCODE_OPIMM, TB_OPCODE_LOAD, TB_OPCODE_JALR, TB_OPCODE_JAL, TB_OPCODE_AUIPC, TB_OPCODE_LUI, \
+  OPCODE_CUSTOM_0, OPCODE_CUSTOM_1, OPCODE_CUSTOM_2, OPCODE_CUSTOM_3
+
+`define RV32_OPCODE_WITH_NO_RS2 \
+  TB_OPCODE_LUI,TB_OPCODE_AUIPC,TB_OPCODE_JAL,TB_OPCODE_JALR,TB_OPCODE_LOAD,TB_OPCODE_OPIMM,TB_OPCODE_FENCE,TB_OPCODE_SYSTEM
 
 `define RV32F_INSTR_WITH_FS1 \
   TB_INS_FMADD, TB_INS_FNMADD, TB_INS_FMSUB, TB_INS_FNMSUB, TB_INS_FADD, TB_INS_FSUB, TB_INS_FMUL, TB_INS_FDIV, TB_INS_FSQRT, \
@@ -43,6 +48,13 @@
 `define RV32F_INSTR_WITH_FS3 \
   TB_INS_FMADD, TB_INS_FNMADD, TB_INS_FMSUB, TB_INS_FNMSUB
   
+`define RV32F_INSTR_WITH_RS1 \
+  TB_INS_FLW, TB_INS_FSW, TB_INS_FMVSX, TB_INS_FCVTSW, TB_INS_FCVTSWU
+
+// `define RV32ZFINX_INSTR_W_RS1 `RV32F_INSTR_WITH_FS1
+`define RV32ZFINX_INSTR_W_RS2 `RV32F_INSTR_WITH_FS2
+`define RV32ZFINX_INSTR_W_RS3 `RV32F_INSTR_WITH_FS3
+
 `define RV32F_OP_WITHOUT_FDIV_FSQRT \
   APU_OP_FMADD, APU_OP_FNMSUB, APU_OP_FADD, APU_OP_FMUL, APU_OP_FSGNJ, APU_OP_FMINMAX, APU_OP_FCMP, \
   APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_I2F, APU_OP_FMSUB, APU_OP_FNMADD, APU_OP_FSUB, APU_OP_FSGNJ_SE, \
@@ -61,14 +73,14 @@
  wildcard bins fmax       =    {TB_INS_FMAX}; \
  wildcard bins fcvtws     =    {TB_INS_FCVTWS}; \
  wildcard bins fcvtwus    =    {TB_INS_FCVTWUS}; \
- wildcard bins fmvxs      =    {TB_INS_FMVXS}; \
+ wildcard bins fmvxw      =    {TB_INS_FMVXS}; \
  wildcard bins feqs       =    {TB_INS_FEQS}; \
  wildcard bins flts       =    {TB_INS_FLTS}; \
  wildcard bins fles       =    {TB_INS_FLES}; \
  wildcard bins fclass     =    {TB_INS_FCLASS}; \
  wildcard bins fcvtsw     =    {TB_INS_FCVTSW}; \
  wildcard bins fcvtswu    =    {TB_INS_FCVTSWU}; \
- wildcard bins fmvsw      =    {TB_INS_FMVSX}; \
+ wildcard bins fmvwx      =    {TB_INS_FMVSX}; \
  wildcard bins fmadd      =    {TB_INS_FMADD}; \
  wildcard bins fmsub      =    {TB_INS_FMSUB}; \
  wildcard bins fnmsub     =    {TB_INS_FNMSUB}; \
@@ -234,6 +246,7 @@
  // bins apu_op_fsgnj_se   =    {APU_OP_FSGNJ_SE}; \ exclude this from macro because it is fmv for RV32F
  // bins apu_op_f2f        =    {APU_OP_F2F};      \ exclude this from above macro because it is for RV32D
 
+// cv32e40p opcode (exclude compress and f-compress)
 `define CV32E40P_INSTR_OPCODE_BIT_6_0_BINS__NO_RV32C_FC \
  bins system_opcode          =    {TB_OPCODE_SYSTEM}; \
  bins fence_opcode           =    {TB_OPCODE_FENCE}; \
@@ -258,6 +271,7 @@
  bins xpulp_custom_2         =    {OPCODE_CUSTOM_2}; \
  bins xpulp_custom_3         =    {OPCODE_CUSTOM_3};
 
+// cv32e40p opcode (exclude compress, f-compress, f-load/store)
 `define CV32E40P_INSTR_OPCODE_BIT_6_0_BINS__NO_RV32C_FC_FPLS \
  bins system_opcode          =    {TB_OPCODE_SYSTEM}; \
  bins fence_opcode           =    {TB_OPCODE_FENCE}; \
@@ -275,6 +289,24 @@
  bins fpu_fnmadd_opcode      =    {TB_OPCODE_OP_FNMADD}; \
  bins fpu_fmsub_opcode       =    {TB_OPCODE_OP_FMSUB}; \
  bins fpu_fnmsub_opcode      =    {TB_OPCODE_OP_FNMSUB}; \
+ bins xpulp_custom_0         =    {OPCODE_CUSTOM_0}; \
+ bins xpulp_custom_1         =    {OPCODE_CUSTOM_1}; \
+ bins xpulp_custom_2         =    {OPCODE_CUSTOM_2}; \
+ bins xpulp_custom_3         =    {OPCODE_CUSTOM_3};
+
+// cv32e40p opcode (exclude compress, f-compress and f)
+`define CV32E40P_INSTR_OPCODE_BIT_6_0_BINS__NO_RV32C_FC_F \
+ bins system_opcode          =    {TB_OPCODE_SYSTEM}; \
+ bins fence_opcode           =    {TB_OPCODE_FENCE}; \
+ bins op_opcode              =    {TB_OPCODE_OP}; \
+ bins opimm_opcode           =    {TB_OPCODE_OPIMM}; \
+ bins store_opcode           =    {TB_OPCODE_STORE}; \
+ bins load_opcode            =    {TB_OPCODE_LOAD}; \
+ bins branch_opcode          =    {TB_OPCODE_BRANCH}; \
+ bins jalr_opcode            =    {TB_OPCODE_JALR}; \
+ bins jal_opcode             =    {TB_OPCODE_JAL}; \
+ bins auipc_opcode           =    {TB_OPCODE_AUIPC}; \
+ bins lui_opcode             =    {TB_OPCODE_LUI}; \
  bins xpulp_custom_0         =    {OPCODE_CUSTOM_0}; \
  bins xpulp_custom_1         =    {OPCODE_CUSTOM_1}; \
  bins xpulp_custom_2         =    {OPCODE_CUSTOM_2}; \

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb.sv
@@ -511,22 +511,28 @@ module uvmt_cv32e40p_tb;
   uvmt_cv32e40p_cov_if cov_if(
     .clk_i(clknrst_if.clk),
     .rst_ni(clknrst_if.reset_n),
+
     .if_stage_instr_rvalid_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.if_stage_i.instr_rvalid_i),
     .if_stage_instr_rdata_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.if_stage_i.instr_rdata_i),
+
     .id_stage_instr_valid_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.instr_valid_i),
     .id_stage_instr_rdata_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.instr_rdata_i),
+    .id_stage_id_valid_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.id_valid_o),
+    .id_stage_apu_op_ex_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.apu_op_ex_o),
+    .id_stage_apu_en_ex_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.apu_en_ex_o),
+
     .apu_req(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.apu_req_o),
     .apu_gnt(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.apu_gnt_i),
     .apu_busy(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.apu_busy_i),
     .apu_op(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.apu_op_o),
     .apu_rvalid_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.apu_rvalid_i),
     .apu_perf_wb_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.apu_perf_wb_o),
-    .id_stage_apu_op_ex_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.apu_op_ex_o),
-    .id_stage_apu_en_ex_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.apu_en_ex_o),
+
     .regfile_waddr_wb_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.regfile_waddr_wb_o),
     .regfile_we_wb_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.regfile_we_wb_o),
     .regfile_alu_waddr_ex_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.regfile_alu_waddr_fw_o),
     .regfile_alu_we_ex_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.regfile_alu_we_fw_o),
+
     .ex_mulh_active(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.mulh_active),
     .ex_mult_op_ex(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.mult_operator_i),
     .ex_data_misaligned_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.data_misaligned_i),
@@ -536,6 +542,7 @@ module uvmt_cv32e40p_tb;
     .ex_regfile_alu_we_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.regfile_alu_we_i),
     .ex_apu_valid(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.apu_valid),
     .ex_apu_rvalid_q(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.apu_rvalid_q),
+
     .debug_req_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.controller_i.debug_req_pending),
     .debug_mode_q(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.controller_i.debug_mode_q),
     .dcsr_q(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.cs_registers_i.dcsr_q),


### PR DESCRIPTION
1) Enable cp_last_fpu_apu_op_at_contention for fpu latency 0 and 2; 
2) Add ccp related to operand forwarding of current rd(non_fpu) to next rs(fpu)