### PR TITLE
Addition of a regress file for unused v1 tests & and fixes for v2 environment

### DIFF
--- a/cv32e40p/regress/cv32e40pv2_legacy_v1.yaml
+++ b/cv32e40p/regress/cv32e40pv2_legacy_v1.yaml
@@ -1,0 +1,209 @@
+name: cv32e40pv2_legacy_v1
+description: regression for CV32E40Pv2, containing all tests not in any of other v2 files, which focus mainly on legacy
+
+# List of builds
+builds:
+  clean_fw:
+    cmd: make clean-bsp clean_test_programs
+    dir: cv32e40p/sim/uvmt
+  clean_corev-dv:
+    cmd: make clean_riscv-dv clone_riscv-dv
+    dir: cv32e40p/sim/uvmt
+  uvmt_cv32e40p:
+    cmd: make comp comp_corev-dv
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp
+
+# List of tests
+tests:
+###################################################################################################
+############ START List of tests that are not in any of the 4 files mentionned above
+
+  hello-world:
+    build: uvmt_cv32e40p
+    description: world
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=hello-world CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  corev_rand_arithmetic_base_test:
+    build: uvmt_cv32e40p
+    description: corev_rand_arithmetic_base_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_arithmetic_base_test CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  corev_rand_illegal_instr_test:
+    build: uvmt_cv32e40p
+    description: corev_rand_illegal_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_illegal_instr_test CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  corev_rand_instr_long_stall:
+    build: uvmt_cv32e40p
+    description: corev_rand_instr_long_stall
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_instr_long_stall CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  corev_rand_instr_test:
+    build: uvmt_cv32e40p
+    description: corev_rand_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_instr_test CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  corev_rand_jump_stress_test:
+    build: uvmt_cv32e40p
+    description: corev_rand_jump_stress_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_jump_stress_test CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  all_csr_por:
+    build: uvmt_cv32e40p
+    description: all_csr_por
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=all_csr_por CFG_PLUSARGS="+UVM_TIMEOUT=300000000"
+
+  branch_zero:
+    build: uvmt_cv32e40p
+    description: branch_zero
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=branch_zero CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  csr_instr_asm:
+    build: uvmt_cv32e40p
+    description: csr_instr_asm
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=csr_instr_asm CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  coremark:
+    build: uvmt_cv32e40p
+    description: coremark
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=coremark CFG_PLUSARGS="+UVM_TIMEOUT=3000000000"
+
+  cv32e40p_readonly_csr_access_test:
+    build: uvmt_cv32e40p
+    description: cv32e40p_readonly_csr_access_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=cv32e40p_readonly_csr_access_test CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  debug_test_trigger:
+    build: uvmt_cv32e40p
+    description: debug_test_trigger
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=debug_test_trigger CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  dhrystone:
+    build: uvmt_cv32e40p
+    description: dhrystone
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=dhrystone CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  fibonacci:
+    build: uvmt_cv32e40p
+    description: fibonacci
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=fibonacci CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  generic_exception_test:
+    build: uvmt_cv32e40p
+    description: generic_exception_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=generic_exception_test CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  hpmcounter_basic_test:
+    build: uvmt_cv32e40p
+    description: hpmcounter_basic_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=hpmcounter_basic_test CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  hpmcounter_hazard_test:
+    build: uvmt_cv32e40p
+    description: hpmcounter_hazard_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=hpmcounter_hazard_test CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  illegal:
+    build: uvmt_cv32e40p
+    description: illegal
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=illegal CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  illegal_instr_test:
+    build: uvmt_cv32e40p
+    description: illegal_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=illegal_instr_test CFG_PLUSARGS="+UVM_TIMEOUT=3000000000"
+
+  isa_fcov_holes:
+    build: uvmt_cv32e40p
+    description: isa_fcov_holes
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=isa_fcov_holes CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  load_store_rs1_zero:
+    build: uvmt_cv32e40p
+    description: load_store_rs1_zero
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=load_store_rs1_zero CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  matmul_32b_float:
+    build: uvmt_cv32e40p
+    description: matmul_32b_float
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=matmul_32b_float CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  matmul_32b_int:
+    build: uvmt_cv32e40p
+    description: matmul_32b_int
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=matmul_32b_int CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  mhpmcounter29_csr_access_test_1:
+    build: uvmt_cv32e40p
+    description: mhpmcounter29_csr_access_test_1
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=mhpmcounter29_csr_access_test_1 CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  mhpmcounter29_csr_access_test_2:
+    build: uvmt_cv32e40p
+    description: mhpmcounter29_csr_access_test_2
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=mhpmcounter29_csr_access_test_2 CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  misalign:
+    build: uvmt_cv32e40p
+    description: misalign
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=misalign CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  modeled_csr_por:
+    build: uvmt_cv32e40p
+    description: modeled_csr_por
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=modeled_csr_por CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  perf_counters_instructions:
+    build: uvmt_cv32e40p
+    description: perf_counters_instructions
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=perf_counters_instructions CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  requested_csr_por:
+    build: uvmt_cv32e40p
+    description: requested_csr_por
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=requested_csr_por CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  riscv_arithmetic_basic_test_0:
+    build: uvmt_cv32e40p
+    description: riscv_arithmetic_basic_test_0
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=riscv_arithmetic_basic_test_0 CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+  riscv_arithmetic_basic_test_1:
+    build: uvmt_cv32e40p
+    description: riscv_arithmetic_basic_test_1
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=riscv_arithmetic_basic_test_1 CFG_PLUSARGS="+UVM_TIMEOUT=30000000"
+
+############ END List of tests that are not in any of the v2 regress list
+###################################################################################################

--- a/cv32e40p/tests/programs/custom/cv32e40p_csr_access_test/cv32e40p_csr_access_test.S
+++ b/cv32e40p/tests/programs/custom/cv32e40p_csr_access_test/cv32e40p_csr_access_test.S
@@ -11,15 +11,29 @@
 .section .text
 .global u_sw_irq_handler
 
-	#ifdef PULP
-		#if defined(FPU) && !defined(ZFINX)
+#define MSTATUS_HARDWIRED 0x00001800
+
+#if defined(PULP)
+	#if defined(FPU) && !defined(ZFINX)
+		#define HAS_FPU 1
 		#define EXP_MISA 0x40801124
-		#else
-		#define EXP_MISA 0x40801104
-		#endif
+		#define MSTATUS_MASK 0x00006088
 	#else
-	#define EXP_MISA 0x40001104
+		#define HAS_FPU 0
+		#define EXP_MISA 0x40801104
+		#define MSTATUS_MASK 0x00000088
 	#endif
+#else
+#define HAS_FPU 0
+#define EXP_MISA 0x40001104
+#define MSTATUS_MASK 0x00000088
+#endif
+
+# for mstatus, value will be :
+# csrr_w(i)_ : (MSTATUS_HARDWIRED | (write_value & MSTATUS_MASK))
+# csrr_s(i)_ : (MSTATUS_HARDWIRED | ((previous_value | write_value) & MSTATUS_MASK))
+# csrr_c(i)_ : (MSTATUS_HARDWIRED | ((previous_value & ~(write_value)) & MSTATUS_MASK))
+# Only the first group of mstatus accesses will be self-checked. For subsequent accesses to mstatus bne instructions will not be executed if F ext is present
 
 ###############################################################################
 #
@@ -545,42 +559,42 @@ main:
 	# mstatus
 	li x7, 0xa5a5a5a5
 	csrrw x12, 768, x7
-	li x7, 0x00001800
+	li x7, (MSTATUS_HARDWIRED | (0x00001800 & MSTATUS_MASK))
 	bne x7, x12, csr_fail
 	li x7, 0x5a5a5a5a
 	csrrw x12, 768, x7
-	li x7, 0x00001880
+	li x7, (MSTATUS_HARDWIRED | (0xa5a5a5a5 & MSTATUS_MASK))
 	bne x7, x12, csr_fail
 	li x7, 0x197aa0ad
 	csrrw x12, 768, x7
-	li x7, 0x00001808
+	li x7, (MSTATUS_HARDWIRED | (0x5a5a5a5a & MSTATUS_MASK))
 	bne x7, x12, csr_fail
 	li x7, 0xa5a5a5a5
 	csrrs x12, 768, x7
-	li x7, 0x00001888
+	li x7, (MSTATUS_HARDWIRED | (0x197aa0ad & MSTATUS_MASK)) # (= x1888 or x3888 if FPU)
 	bne x7, x12, csr_fail
 	li x7, 0x5a5a5a5a
 	csrrs x12, 768, x7
-	li x7, 0x00001888
+	li x7, (MSTATUS_HARDWIRED | ((0x00003888 | 0xa5a5a5a5) & MSTATUS_MASK)) # (= x1888 or x3888 if FPU, 3888 & MSTATUS_MASK for no FPU = 0x1888)
 	bne x7, x12, csr_fail
 	li x7, 0xd3d179f8
 	csrrs x12, 768, x7
-	li x7, 0x00001888
+	li x7, (MSTATUS_HARDWIRED | ((0x80007888 | 0x5a5a5a5a) & (MSTATUS_MASK | (HAS_FPU<<31) )) ) # (= x1888 or x80007888 if FPU, 80007888 & MSTATUS_MASK for no FPU = 0x1888)
 	bne x7, x12, csr_fail
 	li x7, 0xa5a5a5a5
 	csrrc x12, 768, x7
-	li x7, 0x00001888
+	li x7, (MSTATUS_HARDWIRED | ((0x80007888 | 0xd3d179f8) & (MSTATUS_MASK | (HAS_FPU<<31) )) ) # (= x1888 or x80007888 if FPU, 80007888 & MSTATUS_MASK for no FPU = 0x1888)
 	bne x7, x12, csr_fail
 	li x7, 0x5a5a5a5a
 	csrrc x12, 768, x7
-	li x7, 0x00001808
+	li x7, (MSTATUS_HARDWIRED | ((0x80007888 & ~(0xa5a5a5a5)) & MSTATUS_MASK))
 	bne x7, x12, csr_fail
 	li x7, 0x111776a9
 	csrrc x12, 768, x7
-	li x7, 0x00001800
+	li x7, (MSTATUS_HARDWIRED | ((0x00005808 & ~(0x5a5a5a5a)) & MSTATUS_MASK))
 	bne x7, x12, csr_fail
 	csrrwi x12, 768, 0b00101
-	li x7, 0x00001800
+	li x7, (MSTATUS_HARDWIRED | ((0x00001800 & ~(0x111776a9)) & MSTATUS_MASK))
 	bne x7, x12, csr_fail
 	csrrwi x12, 768, 0b11010
 	li x7, 0x00001800
@@ -1843,66 +1857,102 @@ _start1:
 	li x14, 0xa5a5a5a5
 	csrrw x1, 768, x14
 	li x14, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x14, x1, csr_fail
+	#endif
 	li x14, 0x5a5a5a5a
 	csrrw x1, 768, x14
 	li x14, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x14, x1, csr_fail
+	#endif
 	li x14, 0x42b2dbf7
 	csrrw x1, 768, x14
 	li x14, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x14, x1, csr_fail
+	#endif
 	li x14, 0xa5a5a5a5
 	csrrs x1, 768, x14
 	li x14, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x14, x1, csr_fail
+	#endif
 	li x14, 0x5a5a5a5a
 	csrrs x1, 768, x14
 	li x14, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x14, x1, csr_fail
+	#endif
 	li x14, 0xdbaded82
 	csrrs x1, 768, x14
 	li x14, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x14, x1, csr_fail
+	#endif
 	li x14, 0xa5a5a5a5
 	csrrc x1, 768, x14
 	li x14, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x14, x1, csr_fail
+	#endif
 	li x14, 0x5a5a5a5a
 	csrrc x1, 768, x14
 	li x14, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x14, x1, csr_fail
+	#endif
 	li x14, 0x3b29374d
 	csrrc x1, 768, x14
 	li x14, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x14, x1, csr_fail
+	#endif
 	csrrwi x1, 768, 0b00101
 	li x14, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x14, x1, csr_fail
+	#endif
 	csrrwi x1, 768, 0b11010
 	li x14, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x14, x1, csr_fail
+	#endif
 	csrrwi x1, 768, 0b10100
 	li x14, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x14, x1, csr_fail
+	#endif
 	csrrsi x1, 768, 0b00101
 	li x14, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x14, x1, csr_fail
+	#endif
 	csrrsi x1, 768, 0b11010
 	li x14, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x14, x1, csr_fail
+	#endif
 	csrrsi x1, 768, 0b10010
 	li x14, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x14, x1, csr_fail
+	#endif
 	csrrci x1, 768, 0b00101
 	li x14, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x14, x1, csr_fail
+	#endif
 	csrrci x1, 768, 0b11010
 	li x14, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x14, x1, csr_fail
+	#endif
 	csrrci x1, 768, 0b10111
 	li x14, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x14, x1, csr_fail
+	#endif
 	# misa
 	li x15, 0xa5a5a5a5
 	csrrw x2, 769, x15
@@ -3140,66 +3190,102 @@ _start2:
 	li x8, 0xa5a5a5a5
 	csrrw x1, 768, x8
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x1, csr_fail
+	#endif
 	li x8, 0x5a5a5a5a
 	csrrw x1, 768, x8
 	li x8, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x1, csr_fail
+	#endif
 	li x8, 0xa0e19a2b
 	csrrw x1, 768, x8
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x1, csr_fail
+	#endif
 	li x8, 0xa5a5a5a5
 	csrrs x1, 768, x8
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x1, csr_fail
+	#endif
 	li x8, 0x5a5a5a5a
 	csrrs x1, 768, x8
 	li x8, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x1, csr_fail
+	#endif
 	li x8, 0x746ea947
 	csrrs x1, 768, x8
 	li x8, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x1, csr_fail
+	#endif
 	li x8, 0xa5a5a5a5
 	csrrc x1, 768, x8
 	li x8, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x1, csr_fail
+	#endif
 	li x8, 0x5a5a5a5a
 	csrrc x1, 768, x8
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x1, csr_fail
+	#endif
 	li x8, 0x6d45688c
 	csrrc x1, 768, x8
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x1, csr_fail
+	#endif
 	csrrwi x1, 768, 0b00101
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x1, csr_fail
+	#endif
 	csrrwi x1, 768, 0b11010
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x1, csr_fail
+	#endif
 	csrrwi x1, 768, 0b01100
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x1, csr_fail
+	#endif
 	csrrsi x1, 768, 0b00101
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x1, csr_fail
+	#endif
 	csrrsi x1, 768, 0b11010
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x1, csr_fail
+	#endif
 	csrrsi x1, 768, 0b01000
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x1, csr_fail
+	#endif
 	csrrci x1, 768, 0b00101
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x1, csr_fail
+	#endif
 	csrrci x1, 768, 0b11010
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x1, csr_fail
+	#endif
 	csrrci x1, 768, 0b01100
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x1, csr_fail
+	#endif
 	# misa
 	li x8, 0xa5a5a5a5
 	csrrw x1, 769, x8
@@ -4437,66 +4523,102 @@ _start3:
 	li x8, 0xa5a5a5a5
 	csrrw x12, 768, x8
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x12, csr_fail
+	#endif
 	li x8, 0x5a5a5a5a
 	csrrw x12, 768, x8
 	li x8, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x12, csr_fail
+	#endif
 	li x8, 0xb511a673
 	csrrw x12, 768, x8
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x12, csr_fail
+	#endif
 	li x8, 0xa5a5a5a5
 	csrrs x12, 768, x8
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x12, csr_fail
+	#endif
 	li x8, 0x5a5a5a5a
 	csrrs x12, 768, x8
 	li x8, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x12, csr_fail
+	#endif
 	li x8, 0x3975286f
 	csrrs x12, 768, x8
 	li x8, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x12, csr_fail
+	#endif
 	li x8, 0xa5a5a5a5
 	csrrc x12, 768, x8
 	li x8, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x12, csr_fail
+	#endif
 	li x8, 0x5a5a5a5a
 	csrrc x12, 768, x8
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x12, csr_fail
+	#endif
 	li x8, 0x62ce8bf5
 	csrrc x12, 768, x8
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x12, csr_fail
+	#endif
 	csrrwi x12, 768, 0b00101
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x12, csr_fail
+	#endif
 	csrrwi x12, 768, 0b11010
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x12, csr_fail
+	#endif
 	csrrwi x12, 768, 0b00011
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x12, csr_fail
+	#endif
 	csrrsi x12, 768, 0b00101
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x12, csr_fail
+	#endif
 	csrrsi x12, 768, 0b11010
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x12, csr_fail
+	#endif
 	csrrsi x12, 768, 0b10110
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x12, csr_fail
+	#endif
 	csrrci x12, 768, 0b00101
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x12, csr_fail
+	#endif
 	csrrci x12, 768, 0b11010
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x12, csr_fail
+	#endif
 	csrrci x12, 768, 0b10000
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x12, csr_fail
+	#endif
 	# misa
 	li x8, 0xa5a5a5a5
 	csrrw x12, 769, x8
@@ -5734,66 +5856,102 @@ _start4:
 	li x2, 0xa5a5a5a5
 	csrrw x4, 768, x2
 	li x2, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x4, csr_fail
+	#endif
 	li x2, 0x5a5a5a5a
 	csrrw x4, 768, x2
 	li x2, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x4, csr_fail
+	#endif
 	li x2, 0x8a0e21a3
 	csrrw x4, 768, x2
 	li x2, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x4, csr_fail
+	#endif
 	li x2, 0xa5a5a5a5
 	csrrs x4, 768, x2
 	li x2, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x4, csr_fail
+	#endif
 	li x2, 0x5a5a5a5a
 	csrrs x4, 768, x2
 	li x2, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x4, csr_fail
+	#endif
 	li x2, 0x2e7c6e7a
 	csrrs x4, 768, x2
 	li x2, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x4, csr_fail
+	#endif
 	li x2, 0xa5a5a5a5
 	csrrc x4, 768, x2
 	li x2, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x4, csr_fail
+	#endif
 	li x2, 0x5a5a5a5a
 	csrrc x4, 768, x2
 	li x2, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x4, csr_fail
+	#endif
 	li x2, 0x94dda6f3
 	csrrc x4, 768, x2
 	li x2, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x4, csr_fail
+	#endif
 	csrrwi x4, 768, 0b00101
 	li x2, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x4, csr_fail
+	#endif
 	csrrwi x4, 768, 0b11010
 	li x2, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x4, csr_fail
+	#endif
 	csrrwi x4, 768, 0b11010
 	li x2, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x4, csr_fail
+	#endif
 	csrrsi x4, 768, 0b00101
 	li x2, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x4, csr_fail
+	#endif
 	csrrsi x4, 768, 0b11010
 	li x2, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x4, csr_fail
+	#endif
 	csrrsi x4, 768, 0b00001
 	li x2, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x4, csr_fail
+	#endif
 	csrrci x4, 768, 0b00101
 	li x2, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x4, csr_fail
+	#endif
 	csrrci x4, 768, 0b11010
 	li x2, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x4, csr_fail
+	#endif
 	csrrci x4, 768, 0b00101
 	li x2, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x4, csr_fail
+	#endif
 	# misa
 	li x2, 0xa5a5a5a5
 	csrrw x4, 769, x2
@@ -7031,66 +7189,102 @@ _start5:
 	li x13, 0xa5a5a5a5
 	csrrw x6, 768, x13
 	li x13, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x6, csr_fail
+	#endif
 	li x13, 0x5a5a5a5a
 	csrrw x6, 768, x13
 	li x13, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x6, csr_fail
+	#endif
 	li x13, 0x68c7c730
 	csrrw x6, 768, x13
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x6, csr_fail
+	#endif
 	li x13, 0xa5a5a5a5
 	csrrs x6, 768, x13
 	li x13, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x6, csr_fail
+	#endif
 	li x13, 0x5a5a5a5a
 	csrrs x6, 768, x13
 	li x13, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x6, csr_fail
+	#endif
 	li x13, 0xe711d08f
 	csrrs x6, 768, x13
 	li x13, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x6, csr_fail
+	#endif
 	li x13, 0xa5a5a5a5
 	csrrc x6, 768, x13
 	li x13, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x6, csr_fail
+	#endif
 	li x13, 0x5a5a5a5a
 	csrrc x6, 768, x13
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x6, csr_fail
+	#endif
 	li x13, 0xe6277d3f
 	csrrc x6, 768, x13
 	li x13, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x6, csr_fail
+	#endif
 	csrrwi x6, 768, 0b00101
 	li x13, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x6, csr_fail
+	#endif
 	csrrwi x6, 768, 0b11010
 	li x13, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x6, csr_fail
+	#endif
 	csrrwi x6, 768, 0b01111
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x6, csr_fail
+	#endif
 	csrrsi x6, 768, 0b00101
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x6, csr_fail
+	#endif
 	csrrsi x6, 768, 0b11010
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x6, csr_fail
+	#endif
 	csrrsi x6, 768, 0b01101
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x6, csr_fail
+	#endif
 	csrrci x6, 768, 0b00101
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x6, csr_fail
+	#endif
 	csrrci x6, 768, 0b11010
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x6, csr_fail
+	#endif
 	csrrci x6, 768, 0b11110
 	li x13, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x6, csr_fail
+	#endif
 	# misa
 	li x13, 0xa5a5a5a5
 	csrrw x6, 769, x13
@@ -8328,66 +8522,102 @@ _start6:
 	li x13, 0xa5a5a5a5
 	csrrw x1, 768, x13
 	li x13, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x1, csr_fail
+	#endif
 	li x13, 0x5a5a5a5a
 	csrrw x1, 768, x13
 	li x13, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x1, csr_fail
+	#endif
 	li x13, 0x522ce33d
 	csrrw x1, 768, x13
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x1, csr_fail
+	#endif
 	li x13, 0xa5a5a5a5
 	csrrs x1, 768, x13
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x1, csr_fail
+	#endif
 	li x13, 0x5a5a5a5a
 	csrrs x1, 768, x13
 	li x13, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x1, csr_fail
+	#endif
 	li x13, 0x3f5b7b72
 	csrrs x1, 768, x13
 	li x13, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x1, csr_fail
+	#endif
 	li x13, 0xa5a5a5a5
 	csrrc x1, 768, x13
 	li x13, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x1, csr_fail
+	#endif
 	li x13, 0x5a5a5a5a
 	csrrc x1, 768, x13
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x1, csr_fail
+	#endif
 	li x13, 0x2961b1fd
 	csrrc x1, 768, x13
 	li x13, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x1, csr_fail
+	#endif
 	csrrwi x1, 768, 0b00101
 	li x13, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x1, csr_fail
+	#endif
 	csrrwi x1, 768, 0b11010
 	li x13, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x1, csr_fail
+	#endif
 	csrrwi x1, 768, 0b11001
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x1, csr_fail
+	#endif
 	csrrsi x1, 768, 0b00101
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x1, csr_fail
+	#endif
 	csrrsi x1, 768, 0b11010
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x1, csr_fail
+	#endif
 	csrrsi x1, 768, 0b11001
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x1, csr_fail
+	#endif
 	csrrci x1, 768, 0b00101
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x1, csr_fail
+	#endif
 	csrrci x1, 768, 0b11010
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x1, csr_fail
+	#endif
 	csrrci x1, 768, 0b10101
 	li x13, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x1, csr_fail
+	#endif
 	# misa
 	li x13, 0xa5a5a5a5
 	csrrw x1, 769, x13
@@ -9625,66 +9855,102 @@ _start7:
 	li x15, 0xa5a5a5a5
 	csrrw x11, 768, x15
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x11, csr_fail
+	#endif
 	li x15, 0x5a5a5a5a
 	csrrw x11, 768, x15
 	li x15, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x11, csr_fail
+	#endif
 	li x15, 0x539d6068
 	csrrw x11, 768, x15
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x11, csr_fail
+	#endif
 	li x15, 0xa5a5a5a5
 	csrrs x11, 768, x15
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x11, csr_fail
+	#endif
 	li x15, 0x5a5a5a5a
 	csrrs x11, 768, x15
 	li x15, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x11, csr_fail
+	#endif
 	li x15, 0xb61f748a
 	csrrs x11, 768, x15
 	li x15, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x11, csr_fail
+	#endif
 	li x15, 0xa5a5a5a5
 	csrrc x11, 768, x15
 	li x15, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x11, csr_fail
+	#endif
 	li x15, 0x5a5a5a5a
 	csrrc x11, 768, x15
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x11, csr_fail
+	#endif
 	li x15, 0x6beadff6
 	csrrc x11, 768, x15
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x11, csr_fail
+	#endif
 	csrrwi x11, 768, 0b00101
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x11, csr_fail
+	#endif
 	csrrwi x11, 768, 0b11010
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x11, csr_fail
+	#endif
 	csrrwi x11, 768, 0b01000
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x11, csr_fail
+	#endif
 	csrrsi x11, 768, 0b00101
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x11, csr_fail
+	#endif
 	csrrsi x11, 768, 0b11010
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x11, csr_fail
+	#endif
 	csrrsi x11, 768, 0b00111
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x11, csr_fail
+	#endif
 	csrrci x11, 768, 0b00101
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x11, csr_fail
+	#endif
 	csrrci x11, 768, 0b11010
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x11, csr_fail
+	#endif
 	csrrci x11, 768, 0b11110
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x11, csr_fail
+	#endif
 	# misa
 	li x15, 0xa5a5a5a5
 	csrrw x11, 769, x15
@@ -10922,66 +11188,102 @@ _start8:
 	li x3, 0xa5a5a5a5
 	csrrw x11, 768, x3
 	li x3, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x11, csr_fail
+	#endif
 	li x3, 0x5a5a5a5a
 	csrrw x11, 768, x3
 	li x3, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x11, csr_fail
+	#endif
 	li x3, 0x670734ed
 	csrrw x11, 768, x3
 	li x3, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x11, csr_fail
+	#endif
 	li x3, 0xa5a5a5a5
 	csrrs x11, 768, x3
 	li x3, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x11, csr_fail
+	#endif
 	li x3, 0x5a5a5a5a
 	csrrs x11, 768, x3
 	li x3, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x11, csr_fail
+	#endif
 	li x3, 0xc7016933
 	csrrs x11, 768, x3
 	li x3, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x11, csr_fail
+	#endif
 	li x3, 0xa5a5a5a5
 	csrrc x11, 768, x3
 	li x3, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x11, csr_fail
+	#endif
 	li x3, 0x5a5a5a5a
 	csrrc x11, 768, x3
 	li x3, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x11, csr_fail
+	#endif
 	li x3, 0xb65d115a
 	csrrc x11, 768, x3
 	li x3, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x11, csr_fail
+	#endif
 	csrrwi x11, 768, 0b00101
 	li x3, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x11, csr_fail
+	#endif
 	csrrwi x11, 768, 0b11010
 	li x3, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x11, csr_fail
+	#endif
 	csrrwi x11, 768, 0b11111
 	li x3, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x11, csr_fail
+	#endif
 	csrrsi x11, 768, 0b00101
 	li x3, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x11, csr_fail
+	#endif
 	csrrsi x11, 768, 0b11010
 	li x3, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x11, csr_fail
+	#endif
 	csrrsi x11, 768, 0b10100
 	li x3, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x11, csr_fail
+	#endif
 	csrrci x11, 768, 0b00101
 	li x3, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x11, csr_fail
+	#endif
 	csrrci x11, 768, 0b11010
 	li x3, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x11, csr_fail
+	#endif
 	csrrci x11, 768, 0b11010
 	li x3, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x11, csr_fail
+	#endif
 	# misa
 	li x3, 0xa5a5a5a5
 	csrrw x11, 769, x3
@@ -12219,66 +12521,102 @@ _start9:
 	li x13, 0xa5a5a5a5
 	csrrw x10, 768, x13
 	li x13, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x10, csr_fail
+	#endif
 	li x13, 0x5a5a5a5a
 	csrrw x10, 768, x13
 	li x13, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x10, csr_fail
+	#endif
 	li x13, 0x102c239f
 	csrrw x10, 768, x13
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x10, csr_fail
+	#endif
 	li x13, 0xa5a5a5a5
 	csrrs x10, 768, x13
 	li x13, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x10, csr_fail
+	#endif
 	li x13, 0x5a5a5a5a
 	csrrs x10, 768, x13
 	li x13, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x10, csr_fail
+	#endif
 	li x13, 0x90d9af7c
 	csrrs x10, 768, x13
 	li x13, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x10, csr_fail
+	#endif
 	li x13, 0xa5a5a5a5
 	csrrc x10, 768, x13
 	li x13, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x10, csr_fail
+	#endif
 	li x13, 0x5a5a5a5a
 	csrrc x10, 768, x13
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x10, csr_fail
+	#endif
 	li x13, 0x9e3c631e
 	csrrc x10, 768, x13
 	li x13, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x10, csr_fail
+	#endif
 	csrrwi x10, 768, 0b00101
 	li x13, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x10, csr_fail
+	#endif
 	csrrwi x10, 768, 0b11010
 	li x13, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x10, csr_fail
+	#endif
 	csrrwi x10, 768, 0b10100
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x10, csr_fail
+	#endif
 	csrrsi x10, 768, 0b00101
 	li x13, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x10, csr_fail
+	#endif
 	csrrsi x10, 768, 0b11010
 	li x13, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x10, csr_fail
+	#endif
 	csrrsi x10, 768, 0b10101
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x10, csr_fail
+	#endif
 	csrrci x10, 768, 0b00101
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x10, csr_fail
+	#endif
 	csrrci x10, 768, 0b11010
 	li x13, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x10, csr_fail
+	#endif
 	csrrci x10, 768, 0b10110
 	li x13, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x13, x10, csr_fail
+	#endif
 	# misa
 	li x13, 0xa5a5a5a5
 	csrrw x10, 769, x13
@@ -13516,66 +13854,102 @@ _start10:
 	li x5, 0xa5a5a5a5
 	csrrw x6, 768, x5
 	li x5, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x6, csr_fail
+	#endif
 	li x5, 0x5a5a5a5a
 	csrrw x6, 768, x5
 	li x5, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x6, csr_fail
+	#endif
 	li x5, 0xd6188de4
 	csrrw x6, 768, x5
 	li x5, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x6, csr_fail
+	#endif
 	li x5, 0xa5a5a5a5
 	csrrs x6, 768, x5
 	li x5, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x6, csr_fail
+	#endif
 	li x5, 0x5a5a5a5a
 	csrrs x6, 768, x5
 	li x5, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x6, csr_fail
+	#endif
 	li x5, 0xb52760c4
 	csrrs x6, 768, x5
 	li x5, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x6, csr_fail
+	#endif
 	li x5, 0xa5a5a5a5
 	csrrc x6, 768, x5
 	li x5, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x6, csr_fail
+	#endif
 	li x5, 0x5a5a5a5a
 	csrrc x6, 768, x5
 	li x5, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x6, csr_fail
+	#endif
 	li x5, 0x6f721966
 	csrrc x6, 768, x5
 	li x5, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x6, csr_fail
+	#endif
 	csrrwi x6, 768, 0b00101
 	li x5, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x6, csr_fail
+	#endif
 	csrrwi x6, 768, 0b11010
 	li x5, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x6, csr_fail
+	#endif
 	csrrwi x6, 768, 0b00000
 	li x5, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x6, csr_fail
+	#endif
 	csrrsi x6, 768, 0b00101
 	li x5, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x6, csr_fail
+	#endif
 	csrrsi x6, 768, 0b11010
 	li x5, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x6, csr_fail
+	#endif
 	csrrsi x6, 768, 0b00001
 	li x5, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x6, csr_fail
+	#endif
 	csrrci x6, 768, 0b00101
 	li x5, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x6, csr_fail
+	#endif
 	csrrci x6, 768, 0b11010
 	li x5, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x6, csr_fail
+	#endif
 	csrrci x6, 768, 0b10101
 	li x5, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x6, csr_fail
+	#endif
 	# misa
 	li x5, 0xa5a5a5a5
 	csrrw x6, 769, x5
@@ -14813,66 +15187,102 @@ _start11:
 	li x11, 0xa5a5a5a5
 	csrrw x3, 768, x11
 	li x11, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x11, x3, csr_fail
+	#endif
 	li x11, 0x5a5a5a5a
 	csrrw x3, 768, x11
 	li x11, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x11, x3, csr_fail
+	#endif
 	li x11, 0xa703f9b2
 	csrrw x3, 768, x11
 	li x11, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x11, x3, csr_fail
+	#endif
 	li x11, 0xa5a5a5a5
 	csrrs x3, 768, x11
 	li x11, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x11, x3, csr_fail
+	#endif
 	li x11, 0x5a5a5a5a
 	csrrs x3, 768, x11
 	li x11, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x11, x3, csr_fail
+	#endif
 	li x11, 0x1ebf86c5
 	csrrs x3, 768, x11
 	li x11, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x11, x3, csr_fail
+	#endif
 	li x11, 0xa5a5a5a5
 	csrrc x3, 768, x11
 	li x11, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x11, x3, csr_fail
+	#endif
 	li x11, 0x5a5a5a5a
 	csrrc x3, 768, x11
 	li x11, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x11, x3, csr_fail
+	#endif
 	li x11, 0xd5c5f1ac
 	csrrc x3, 768, x11
 	li x11, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x11, x3, csr_fail
+	#endif
 	csrrwi x3, 768, 0b00101
 	li x11, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x11, x3, csr_fail
+	#endif
 	csrrwi x3, 768, 0b11010
 	li x11, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x11, x3, csr_fail
+	#endif
 	csrrwi x3, 768, 0b11010
 	li x11, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x11, x3, csr_fail
+	#endif
 	csrrsi x3, 768, 0b00101
 	li x11, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x11, x3, csr_fail
+	#endif
 	csrrsi x3, 768, 0b11010
 	li x11, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x11, x3, csr_fail
+	#endif
 	csrrsi x3, 768, 0b11111
 	li x11, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x11, x3, csr_fail
+	#endif
 	csrrci x3, 768, 0b00101
 	li x11, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x11, x3, csr_fail
+	#endif
 	csrrci x3, 768, 0b11010
 	li x11, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x11, x3, csr_fail
+	#endif
 	csrrci x3, 768, 0b01000
 	li x11, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x11, x3, csr_fail
+	#endif
 	# misa
 	li x11, 0xa5a5a5a5
 	csrrw x3, 769, x11
@@ -16110,66 +16520,102 @@ _start12:
 	li x15, 0xa5a5a5a5
 	csrrw x12, 768, x15
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	li x15, 0x5a5a5a5a
 	csrrw x12, 768, x15
 	li x15, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	li x15, 0x1c1fa688
 	csrrw x12, 768, x15
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	li x15, 0xa5a5a5a5
 	csrrs x12, 768, x15
 	li x15, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	li x15, 0x5a5a5a5a
 	csrrs x12, 768, x15
 	li x15, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	li x15, 0x929e21d8
 	csrrs x12, 768, x15
 	li x15, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	li x15, 0xa5a5a5a5
 	csrrc x12, 768, x15
 	li x15, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	li x15, 0x5a5a5a5a
 	csrrc x12, 768, x15
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	li x15, 0x22e459c1
 	csrrc x12, 768, x15
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	csrrwi x12, 768, 0b00101
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	csrrwi x12, 768, 0b11010
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	csrrwi x12, 768, 0b00110
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	csrrsi x12, 768, 0b00101
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	csrrsi x12, 768, 0b11010
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	csrrsi x12, 768, 0b11100
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	csrrci x12, 768, 0b00101
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	csrrci x12, 768, 0b11010
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	csrrci x12, 768, 0b00111
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	# misa
 	li x15, 0xa5a5a5a5
 	csrrw x12, 769, x15
@@ -17407,66 +17853,102 @@ _start13:
 	li x15, 0xa5a5a5a5
 	csrrw x9, 768, x15
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x9, csr_fail
+	#endif
 	li x15, 0x5a5a5a5a
 	csrrw x9, 768, x15
 	li x15, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x9, csr_fail
+	#endif
 	li x15, 0xe3bb0b51
 	csrrw x9, 768, x15
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x9, csr_fail
+	#endif
 	li x15, 0xa5a5a5a5
 	csrrs x9, 768, x15
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x9, csr_fail
+	#endif
 	li x15, 0x5a5a5a5a
 	csrrs x9, 768, x15
 	li x15, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x9, csr_fail
+	#endif
 	li x15, 0xe2bd3b59
 	csrrs x9, 768, x15
 	li x15, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x9, csr_fail
+	#endif
 	li x15, 0xa5a5a5a5
 	csrrc x9, 768, x15
 	li x15, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x9, csr_fail
+	#endif
 	li x15, 0x5a5a5a5a
 	csrrc x9, 768, x15
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x9, csr_fail
+	#endif
 	li x15, 0x741c3cdb
 	csrrc x9, 768, x15
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x9, csr_fail
+	#endif
 	csrrwi x9, 768, 0b00101
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x9, csr_fail
+	#endif
 	csrrwi x9, 768, 0b11010
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x9, csr_fail
+	#endif
 	csrrwi x9, 768, 0b10100
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x9, csr_fail
+	#endif
 	csrrsi x9, 768, 0b00101
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x9, csr_fail
+	#endif
 	csrrsi x9, 768, 0b11010
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x9, csr_fail
+	#endif
 	csrrsi x9, 768, 0b01101
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x9, csr_fail
+	#endif
 	csrrci x9, 768, 0b00101
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x9, csr_fail
+	#endif
 	csrrci x9, 768, 0b11010
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x9, csr_fail
+	#endif
 	csrrci x9, 768, 0b01110
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x9, csr_fail
+	#endif
 	# misa
 	li x15, 0xa5a5a5a5
 	csrrw x9, 769, x15
@@ -18704,66 +19186,102 @@ _start14:
 	li x10, 0xa5a5a5a5
 	csrrw x12, 768, x10
 	li x10, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	li x10, 0x5a5a5a5a
 	csrrw x12, 768, x10
 	li x10, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	li x10, 0xcb257085
 	csrrw x12, 768, x10
 	li x10, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	li x10, 0xa5a5a5a5
 	csrrs x12, 768, x10
 	li x10, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	li x10, 0x5a5a5a5a
 	csrrs x12, 768, x10
 	li x10, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	li x10, 0xeff062da
 	csrrs x12, 768, x10
 	li x10, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	li x10, 0xa5a5a5a5
 	csrrc x12, 768, x10
 	li x10, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	li x10, 0x5a5a5a5a
 	csrrc x12, 768, x10
 	li x10, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	li x10, 0xbe546676
 	csrrc x12, 768, x10
 	li x10, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	csrrwi x12, 768, 0b00101
 	li x10, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	csrrwi x12, 768, 0b11010
 	li x10, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	csrrwi x12, 768, 0b11101
 	li x10, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	csrrsi x12, 768, 0b00101
 	li x10, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	csrrsi x12, 768, 0b11010
 	li x10, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	csrrsi x12, 768, 0b10011
 	li x10, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	csrrci x12, 768, 0b00101
 	li x10, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	csrrci x12, 768, 0b11010
 	li x10, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	csrrci x12, 768, 0b10001
 	li x10, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	# misa
 	li x10, 0xa5a5a5a5
 	csrrw x12, 769, x10
@@ -20001,66 +20519,102 @@ _start15:
 	li x12, 0xa5a5a5a5
 	csrrw x14, 768, x12
 	li x12, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x14, csr_fail
+	#endif
 	li x12, 0x5a5a5a5a
 	csrrw x14, 768, x12
 	li x12, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x14, csr_fail
+	#endif
 	li x12, 0x4c01bfc7
 	csrrw x14, 768, x12
 	li x12, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x14, csr_fail
+	#endif
 	li x12, 0xa5a5a5a5
 	csrrs x14, 768, x12
 	li x12, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x14, csr_fail
+	#endif
 	li x12, 0x5a5a5a5a
 	csrrs x14, 768, x12
 	li x12, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x14, csr_fail
+	#endif
 	li x12, 0x20b8ac50
 	csrrs x14, 768, x12
 	li x12, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x14, csr_fail
+	#endif
 	li x12, 0xa5a5a5a5
 	csrrc x14, 768, x12
 	li x12, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x14, csr_fail
+	#endif
 	li x12, 0x5a5a5a5a
 	csrrc x14, 768, x12
 	li x12, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x14, csr_fail
+	#endif
 	li x12, 0x97f831b8
 	csrrc x14, 768, x12
 	li x12, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x14, csr_fail
+	#endif
 	csrrwi x14, 768, 0b00101
 	li x12, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x14, csr_fail
+	#endif
 	csrrwi x14, 768, 0b11010
 	li x12, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x14, csr_fail
+	#endif
 	csrrwi x14, 768, 0b11011
 	li x12, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x14, csr_fail
+	#endif
 	csrrsi x14, 768, 0b00101
 	li x12, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x14, csr_fail
+	#endif
 	csrrsi x14, 768, 0b11010
 	li x12, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x14, csr_fail
+	#endif
 	csrrsi x14, 768, 0b00110
 	li x12, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x14, csr_fail
+	#endif
 	csrrci x14, 768, 0b00101
 	li x12, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x14, csr_fail
+	#endif
 	csrrci x14, 768, 0b11010
 	li x12, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x14, csr_fail
+	#endif
 	csrrci x14, 768, 0b01101
 	li x12, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x14, csr_fail
+	#endif
 	# misa
 	li x12, 0xa5a5a5a5
 	csrrw x14, 769, x12
@@ -21298,66 +21852,102 @@ _start16:
 	li x3, 0xa5a5a5a5
 	csrrw x14, 768, x3
 	li x3, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x14, csr_fail
+	#endif
 	li x3, 0x5a5a5a5a
 	csrrw x14, 768, x3
 	li x3, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x14, csr_fail
+	#endif
 	li x3, 0x50aed442
 	csrrw x14, 768, x3
 	li x3, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x14, csr_fail
+	#endif
 	li x3, 0xa5a5a5a5
 	csrrs x14, 768, x3
 	li x3, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x14, csr_fail
+	#endif
 	li x3, 0x5a5a5a5a
 	csrrs x14, 768, x3
 	li x3, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x14, csr_fail
+	#endif
 	li x3, 0xdc758590
 	csrrs x14, 768, x3
 	li x3, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x14, csr_fail
+	#endif
 	li x3, 0xa5a5a5a5
 	csrrc x14, 768, x3
 	li x3, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x14, csr_fail
+	#endif
 	li x3, 0x5a5a5a5a
 	csrrc x14, 768, x3
 	li x3, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x14, csr_fail
+	#endif
 	li x3, 0x309c3de2
 	csrrc x14, 768, x3
 	li x3, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x14, csr_fail
+	#endif
 	csrrwi x14, 768, 0b00101
 	li x3, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x14, csr_fail
+	#endif
 	csrrwi x14, 768, 0b11010
 	li x3, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x14, csr_fail
+	#endif
 	csrrwi x14, 768, 0b01011
 	li x3, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x14, csr_fail
+	#endif
 	csrrsi x14, 768, 0b00101
 	li x3, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x14, csr_fail
+	#endif
 	csrrsi x14, 768, 0b11010
 	li x3, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x14, csr_fail
+	#endif
 	csrrsi x14, 768, 0b11110
 	li x3, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x14, csr_fail
+	#endif
 	csrrci x14, 768, 0b00101
 	li x3, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x14, csr_fail
+	#endif
 	csrrci x14, 768, 0b11010
 	li x3, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x14, csr_fail
+	#endif
 	csrrci x14, 768, 0b11011
 	li x3, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x3, x14, csr_fail
+	#endif
 	# misa
 	li x3, 0xa5a5a5a5
 	csrrw x14, 769, x3
@@ -22595,66 +23185,102 @@ _start17:
 	li x1, 0xa5a5a5a5
 	csrrw x15, 768, x1
 	li x1, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x1, x15, csr_fail
+	#endif
 	li x1, 0x5a5a5a5a
 	csrrw x15, 768, x1
 	li x1, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x1, x15, csr_fail
+	#endif
 	li x1, 0xe3382eb6
 	csrrw x15, 768, x1
 	li x1, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x1, x15, csr_fail
+	#endif
 	li x1, 0xa5a5a5a5
 	csrrs x15, 768, x1
 	li x1, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x1, x15, csr_fail
+	#endif
 	li x1, 0x5a5a5a5a
 	csrrs x15, 768, x1
 	li x1, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x1, x15, csr_fail
+	#endif
 	li x1, 0x6481fcaf
 	csrrs x15, 768, x1
 	li x1, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x1, x15, csr_fail
+	#endif
 	li x1, 0xa5a5a5a5
 	csrrc x15, 768, x1
 	li x1, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x1, x15, csr_fail
+	#endif
 	li x1, 0x5a5a5a5a
 	csrrc x15, 768, x1
 	li x1, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x1, x15, csr_fail
+	#endif
 	li x1, 0x19d0d6a7
 	csrrc x15, 768, x1
 	li x1, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x1, x15, csr_fail
+	#endif
 	csrrwi x15, 768, 0b00101
 	li x1, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x1, x15, csr_fail
+	#endif
 	csrrwi x15, 768, 0b11010
 	li x1, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x1, x15, csr_fail
+	#endif
 	csrrwi x15, 768, 0b01110
 	li x1, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x1, x15, csr_fail
+	#endif
 	csrrsi x15, 768, 0b00101
 	li x1, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x1, x15, csr_fail
+	#endif
 	csrrsi x15, 768, 0b11010
 	li x1, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x1, x15, csr_fail
+	#endif
 	csrrsi x15, 768, 0b00011
 	li x1, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x1, x15, csr_fail
+	#endif
 	csrrci x15, 768, 0b00101
 	li x1, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x1, x15, csr_fail
+	#endif
 	csrrci x15, 768, 0b11010
 	li x1, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x1, x15, csr_fail
+	#endif
 	csrrci x15, 768, 0b11111
 	li x1, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x1, x15, csr_fail
+	#endif
 	# misa
 	li x1, 0xa5a5a5a5
 	csrrw x15, 769, x1
@@ -23892,66 +24518,102 @@ _start18:
 	li x15, 0xa5a5a5a5
 	csrrw x12, 768, x15
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	li x15, 0x5a5a5a5a
 	csrrw x12, 768, x15
 	li x15, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	li x15, 0xd3985593
 	csrrw x12, 768, x15
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	li x15, 0xa5a5a5a5
 	csrrs x12, 768, x15
 	li x15, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	li x15, 0x5a5a5a5a
 	csrrs x12, 768, x15
 	li x15, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	li x15, 0x06338dee
 	csrrs x12, 768, x15
 	li x15, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	li x15, 0xa5a5a5a5
 	csrrc x12, 768, x15
 	li x15, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	li x15, 0x5a5a5a5a
 	csrrc x12, 768, x15
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	li x15, 0x3f31406b
 	csrrc x12, 768, x15
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	csrrwi x12, 768, 0b00101
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	csrrwi x12, 768, 0b11010
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	csrrwi x12, 768, 0b11100
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	csrrsi x12, 768, 0b00101
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	csrrsi x12, 768, 0b11010
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	csrrsi x12, 768, 0b10000
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	csrrci x12, 768, 0b00101
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	csrrci x12, 768, 0b11010
 	li x15, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	csrrci x12, 768, 0b10101
 	li x15, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x15, x12, csr_fail
+	#endif
 	# misa
 	li x15, 0xa5a5a5a5
 	csrrw x12, 769, x15
@@ -25189,66 +25851,102 @@ _start19:
 	li x2, 0xa5a5a5a5
 	csrrw x6, 768, x2
 	li x2, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x6, csr_fail
+	#endif
 	li x2, 0x5a5a5a5a
 	csrrw x6, 768, x2
 	li x2, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x6, csr_fail
+	#endif
 	li x2, 0x750b4706
 	csrrw x6, 768, x2
 	li x2, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x6, csr_fail
+	#endif
 	li x2, 0xa5a5a5a5
 	csrrs x6, 768, x2
 	li x2, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x6, csr_fail
+	#endif
 	li x2, 0x5a5a5a5a
 	csrrs x6, 768, x2
 	li x2, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x6, csr_fail
+	#endif
 	li x2, 0x76e5e534
 	csrrs x6, 768, x2
 	li x2, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x6, csr_fail
+	#endif
 	li x2, 0xa5a5a5a5
 	csrrc x6, 768, x2
 	li x2, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x6, csr_fail
+	#endif
 	li x2, 0x5a5a5a5a
 	csrrc x6, 768, x2
 	li x2, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x6, csr_fail
+	#endif
 	li x2, 0xc5522492
 	csrrc x6, 768, x2
 	li x2, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x6, csr_fail
+	#endif
 	csrrwi x6, 768, 0b00101
 	li x2, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x6, csr_fail
+	#endif
 	csrrwi x6, 768, 0b11010
 	li x2, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x6, csr_fail
+	#endif
 	csrrwi x6, 768, 0b00011
 	li x2, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x6, csr_fail
+	#endif
 	csrrsi x6, 768, 0b00101
 	li x2, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x6, csr_fail
+	#endif
 	csrrsi x6, 768, 0b11010
 	li x2, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x6, csr_fail
+	#endif
 	csrrsi x6, 768, 0b11001
 	li x2, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x6, csr_fail
+	#endif
 	csrrci x6, 768, 0b00101
 	li x2, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x6, csr_fail
+	#endif
 	csrrci x6, 768, 0b11010
 	li x2, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x6, csr_fail
+	#endif
 	csrrci x6, 768, 0b00100
 	li x2, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x6, csr_fail
+	#endif
 	# misa
 	li x2, 0xa5a5a5a5
 	csrrw x6, 769, x2
@@ -26486,66 +27184,102 @@ _start20:
 	li x10, 0xa5a5a5a5
 	csrrw x12, 768, x10
 	li x10, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	li x10, 0x5a5a5a5a
 	csrrw x12, 768, x10
 	li x10, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	li x10, 0xf9ae7874
 	csrrw x12, 768, x10
 	li x10, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	li x10, 0xa5a5a5a5
 	csrrs x12, 768, x10
 	li x10, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	li x10, 0x5a5a5a5a
 	csrrs x12, 768, x10
 	li x10, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	li x10, 0x25e2d17c
 	csrrs x12, 768, x10
 	li x10, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	li x10, 0xa5a5a5a5
 	csrrc x12, 768, x10
 	li x10, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	li x10, 0x5a5a5a5a
 	csrrc x12, 768, x10
 	li x10, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	li x10, 0xacedb31b
 	csrrc x12, 768, x10
 	li x10, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	csrrwi x12, 768, 0b00101
 	li x10, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	csrrwi x12, 768, 0b11010
 	li x10, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	csrrwi x12, 768, 0b01000
 	li x10, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	csrrsi x12, 768, 0b00101
 	li x10, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	csrrsi x12, 768, 0b11010
 	li x10, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	csrrsi x12, 768, 0b11111
 	li x10, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	csrrci x12, 768, 0b00101
 	li x10, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	csrrci x12, 768, 0b11010
 	li x10, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	csrrci x12, 768, 0b11010
 	li x10, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x10, x12, csr_fail
+	#endif
 	# misa
 	li x10, 0xa5a5a5a5
 	csrrw x12, 769, x10
@@ -27783,66 +28517,102 @@ _start21:
 	li x2, 0xa5a5a5a5
 	csrrw x5, 768, x2
 	li x2, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x5, csr_fail
+	#endif
 	li x2, 0x5a5a5a5a
 	csrrw x5, 768, x2
 	li x2, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x5, csr_fail
+	#endif
 	li x2, 0xfc0955c6
 	csrrw x5, 768, x2
 	li x2, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x5, csr_fail
+	#endif
 	li x2, 0xa5a5a5a5
 	csrrs x5, 768, x2
 	li x2, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x5, csr_fail
+	#endif
 	li x2, 0x5a5a5a5a
 	csrrs x5, 768, x2
 	li x2, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x5, csr_fail
+	#endif
 	li x2, 0x039b5889
 	csrrs x5, 768, x2
 	li x2, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x5, csr_fail
+	#endif
 	li x2, 0xa5a5a5a5
 	csrrc x5, 768, x2
 	li x2, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x5, csr_fail
+	#endif
 	li x2, 0x5a5a5a5a
 	csrrc x5, 768, x2
 	li x2, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x5, csr_fail
+	#endif
 	li x2, 0xe70a7e6d
 	csrrc x5, 768, x2
 	li x2, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x5, csr_fail
+	#endif
 	csrrwi x5, 768, 0b00101
 	li x2, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x5, csr_fail
+	#endif
 	csrrwi x5, 768, 0b11010
 	li x2, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x5, csr_fail
+	#endif
 	csrrwi x5, 768, 0b11111
 	li x2, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x5, csr_fail
+	#endif
 	csrrsi x5, 768, 0b00101
 	li x2, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x5, csr_fail
+	#endif
 	csrrsi x5, 768, 0b11010
 	li x2, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x5, csr_fail
+	#endif
 	csrrsi x5, 768, 0b00100
 	li x2, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x5, csr_fail
+	#endif
 	csrrci x5, 768, 0b00101
 	li x2, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x5, csr_fail
+	#endif
 	csrrci x5, 768, 0b11010
 	li x2, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x5, csr_fail
+	#endif
 	csrrci x5, 768, 0b10100
 	li x2, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x2, x5, csr_fail
+	#endif
 	# misa
 	li x2, 0xa5a5a5a5
 	csrrw x5, 769, x2
@@ -29080,66 +29850,102 @@ _start22:
 	li x9, 0xa5a5a5a5
 	csrrw x3, 768, x9
 	li x9, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x9, x3, csr_fail
+	#endif
 	li x9, 0x5a5a5a5a
 	csrrw x3, 768, x9
 	li x9, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x9, x3, csr_fail
+	#endif
 	li x9, 0xe9d662de
 	csrrw x3, 768, x9
 	li x9, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x9, x3, csr_fail
+	#endif
 	li x9, 0xa5a5a5a5
 	csrrs x3, 768, x9
 	li x9, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x9, x3, csr_fail
+	#endif
 	li x9, 0x5a5a5a5a
 	csrrs x3, 768, x9
 	li x9, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x9, x3, csr_fail
+	#endif
 	li x9, 0xd225a1b6
 	csrrs x3, 768, x9
 	li x9, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x9, x3, csr_fail
+	#endif
 	li x9, 0xa5a5a5a5
 	csrrc x3, 768, x9
 	li x9, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x9, x3, csr_fail
+	#endif
 	li x9, 0x5a5a5a5a
 	csrrc x3, 768, x9
 	li x9, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x9, x3, csr_fail
+	#endif
 	li x9, 0x01fe75a5
 	csrrc x3, 768, x9
 	li x9, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x9, x3, csr_fail
+	#endif
 	csrrwi x3, 768, 0b00101
 	li x9, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x9, x3, csr_fail
+	#endif
 	csrrwi x3, 768, 0b11010
 	li x9, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x9, x3, csr_fail
+	#endif
 	csrrwi x3, 768, 0b10100
 	li x9, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x9, x3, csr_fail
+	#endif
 	csrrsi x3, 768, 0b00101
 	li x9, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x9, x3, csr_fail
+	#endif
 	csrrsi x3, 768, 0b11010
 	li x9, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x9, x3, csr_fail
+	#endif
 	csrrsi x3, 768, 0b10111
 	li x9, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x9, x3, csr_fail
+	#endif
 	csrrci x3, 768, 0b00101
 	li x9, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x9, x3, csr_fail
+	#endif
 	csrrci x3, 768, 0b11010
 	li x9, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x9, x3, csr_fail
+	#endif
 	csrrci x3, 768, 0b11110
 	li x9, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x9, x3, csr_fail
+	#endif
 	# misa
 	li x9, 0xa5a5a5a5
 	csrrw x3, 769, x9
@@ -30377,66 +31183,102 @@ _start23:
 	li x5, 0xa5a5a5a5
 	csrrw x4, 768, x5
 	li x5, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x4, csr_fail
+	#endif
 	li x5, 0x5a5a5a5a
 	csrrw x4, 768, x5
 	li x5, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x4, csr_fail
+	#endif
 	li x5, 0x573b1953
 	csrrw x4, 768, x5
 	li x5, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x4, csr_fail
+	#endif
 	li x5, 0xa5a5a5a5
 	csrrs x4, 768, x5
 	li x5, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x4, csr_fail
+	#endif
 	li x5, 0x5a5a5a5a
 	csrrs x4, 768, x5
 	li x5, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x4, csr_fail
+	#endif
 	li x5, 0x88b0531b
 	csrrs x4, 768, x5
 	li x5, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x4, csr_fail
+	#endif
 	li x5, 0xa5a5a5a5
 	csrrc x4, 768, x5
 	li x5, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x4, csr_fail
+	#endif
 	li x5, 0x5a5a5a5a
 	csrrc x4, 768, x5
 	li x5, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x4, csr_fail
+	#endif
 	li x5, 0x886425d0
 	csrrc x4, 768, x5
 	li x5, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x4, csr_fail
+	#endif
 	csrrwi x4, 768, 0b00101
 	li x5, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x4, csr_fail
+	#endif
 	csrrwi x4, 768, 0b11010
 	li x5, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x4, csr_fail
+	#endif
 	csrrwi x4, 768, 0b11000
 	li x5, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x4, csr_fail
+	#endif
 	csrrsi x4, 768, 0b00101
 	li x5, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x4, csr_fail
+	#endif
 	csrrsi x4, 768, 0b11010
 	li x5, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x4, csr_fail
+	#endif
 	csrrsi x4, 768, 0b10000
 	li x5, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x4, csr_fail
+	#endif
 	csrrci x4, 768, 0b00101
 	li x5, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x4, csr_fail
+	#endif
 	csrrci x4, 768, 0b11010
 	li x5, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x4, csr_fail
+	#endif
 	csrrci x4, 768, 0b01101
 	li x5, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x5, x4, csr_fail
+	#endif
 	# misa
 	li x5, 0xa5a5a5a5
 	csrrw x4, 769, x5
@@ -31674,66 +32516,102 @@ _start24:
 	li x7, 0xa5a5a5a5
 	csrrw x15, 768, x7
 	li x7, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x15, csr_fail
+	#endif
 	li x7, 0x5a5a5a5a
 	csrrw x15, 768, x7
 	li x7, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x15, csr_fail
+	#endif
 	li x7, 0x7d1c3f82
 	csrrw x15, 768, x7
 	li x7, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x15, csr_fail
+	#endif
 	li x7, 0xa5a5a5a5
 	csrrs x15, 768, x7
 	li x7, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x15, csr_fail
+	#endif
 	li x7, 0x5a5a5a5a
 	csrrs x15, 768, x7
 	li x7, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x15, csr_fail
+	#endif
 	li x7, 0xd6aa8f2d
 	csrrs x15, 768, x7
 	li x7, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x15, csr_fail
+	#endif
 	li x7, 0xa5a5a5a5
 	csrrc x15, 768, x7
 	li x7, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x15, csr_fail
+	#endif
 	li x7, 0x5a5a5a5a
 	csrrc x15, 768, x7
 	li x7, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x15, csr_fail
+	#endif
 	li x7, 0x0cb8549b
 	csrrc x15, 768, x7
 	li x7, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x15, csr_fail
+	#endif
 	csrrwi x15, 768, 0b00101
 	li x7, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x15, csr_fail
+	#endif
 	csrrwi x15, 768, 0b11010
 	li x7, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x15, csr_fail
+	#endif
 	csrrwi x15, 768, 0b01010
 	li x7, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x15, csr_fail
+	#endif
 	csrrsi x15, 768, 0b00101
 	li x7, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x15, csr_fail
+	#endif
 	csrrsi x15, 768, 0b11010
 	li x7, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x15, csr_fail
+	#endif
 	csrrsi x15, 768, 0b10011
 	li x7, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x15, csr_fail
+	#endif
 	csrrci x15, 768, 0b00101
 	li x7, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x15, csr_fail
+	#endif
 	csrrci x15, 768, 0b11010
 	li x7, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x15, csr_fail
+	#endif
 	csrrci x15, 768, 0b11011
 	li x7, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x15, csr_fail
+	#endif
 	# misa
 	li x7, 0xa5a5a5a5
 	csrrw x15, 769, x7
@@ -32971,66 +33849,102 @@ _start25:
 	li x7, 0xa5a5a5a5
 	csrrw x2, 768, x7
 	li x7, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x2, csr_fail
+	#endif
 	li x7, 0x5a5a5a5a
 	csrrw x2, 768, x7
 	li x7, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x2, csr_fail
+	#endif
 	li x7, 0x627c6f93
 	csrrw x2, 768, x7
 	li x7, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x2, csr_fail
+	#endif
 	li x7, 0xa5a5a5a5
 	csrrs x2, 768, x7
 	li x7, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x2, csr_fail
+	#endif
 	li x7, 0x5a5a5a5a
 	csrrs x2, 768, x7
 	li x7, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x2, csr_fail
+	#endif
 	li x7, 0x55ef2b06
 	csrrs x2, 768, x7
 	li x7, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x2, csr_fail
+	#endif
 	li x7, 0xa5a5a5a5
 	csrrc x2, 768, x7
 	li x7, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x2, csr_fail
+	#endif
 	li x7, 0x5a5a5a5a
 	csrrc x2, 768, x7
 	li x7, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x2, csr_fail
+	#endif
 	li x7, 0xf8cad51f
 	csrrc x2, 768, x7
 	li x7, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x2, csr_fail
+	#endif
 	csrrwi x2, 768, 0b00101
 	li x7, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x2, csr_fail
+	#endif
 	csrrwi x2, 768, 0b11010
 	li x7, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x2, csr_fail
+	#endif
 	csrrwi x2, 768, 0b01111
 	li x7, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x2, csr_fail
+	#endif
 	csrrsi x2, 768, 0b00101
 	li x7, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x2, csr_fail
+	#endif
 	csrrsi x2, 768, 0b11010
 	li x7, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x2, csr_fail
+	#endif
 	csrrsi x2, 768, 0b11001
 	li x7, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x2, csr_fail
+	#endif
 	csrrci x2, 768, 0b00101
 	li x7, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x2, csr_fail
+	#endif
 	csrrci x2, 768, 0b11010
 	li x7, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x2, csr_fail
+	#endif
 	csrrci x2, 768, 0b00111
 	li x7, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x7, x2, csr_fail
+	#endif
 	# misa
 	li x7, 0xa5a5a5a5
 	csrrw x2, 769, x7
@@ -34268,66 +35182,102 @@ _start26:
 	li x12, 0xa5a5a5a5
 	csrrw x15, 768, x12
 	li x12, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x15, csr_fail
+	#endif
 	li x12, 0x5a5a5a5a
 	csrrw x15, 768, x12
 	li x12, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x15, csr_fail
+	#endif
 	li x12, 0x8a0e612a
 	csrrw x15, 768, x12
 	li x12, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x15, csr_fail
+	#endif
 	li x12, 0xa5a5a5a5
 	csrrs x15, 768, x12
 	li x12, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x15, csr_fail
+	#endif
 	li x12, 0x5a5a5a5a
 	csrrs x15, 768, x12
 	li x12, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x15, csr_fail
+	#endif
 	li x12, 0xc82366ed
 	csrrs x15, 768, x12
 	li x12, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x15, csr_fail
+	#endif
 	li x12, 0xa5a5a5a5
 	csrrc x15, 768, x12
 	li x12, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x15, csr_fail
+	#endif
 	li x12, 0x5a5a5a5a
 	csrrc x15, 768, x12
 	li x12, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x15, csr_fail
+	#endif
 	li x12, 0xdf9f73bc
 	csrrc x15, 768, x12
 	li x12, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x15, csr_fail
+	#endif
 	csrrwi x15, 768, 0b00101
 	li x12, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x15, csr_fail
+	#endif
 	csrrwi x15, 768, 0b11010
 	li x12, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x15, csr_fail
+	#endif
 	csrrwi x15, 768, 0b00001
 	li x12, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x15, csr_fail
+	#endif
 	csrrsi x15, 768, 0b00101
 	li x12, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x15, csr_fail
+	#endif
 	csrrsi x15, 768, 0b11010
 	li x12, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x15, csr_fail
+	#endif
 	csrrsi x15, 768, 0b11101
 	li x12, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x15, csr_fail
+	#endif
 	csrrci x15, 768, 0b00101
 	li x12, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x15, csr_fail
+	#endif
 	csrrci x15, 768, 0b11010
 	li x12, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x15, csr_fail
+	#endif
 	csrrci x15, 768, 0b10011
 	li x12, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x12, x15, csr_fail
+	#endif
 	# misa
 	li x12, 0xa5a5a5a5
 	csrrw x15, 769, x12
@@ -35565,66 +36515,102 @@ _start27:
 	li x4, 0xa5a5a5a5
 	csrrw x1, 768, x4
 	li x4, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x1, csr_fail
+	#endif
 	li x4, 0x5a5a5a5a
 	csrrw x1, 768, x4
 	li x4, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x1, csr_fail
+	#endif
 	li x4, 0x1e189333
 	csrrw x1, 768, x4
 	li x4, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x1, csr_fail
+	#endif
 	li x4, 0xa5a5a5a5
 	csrrs x1, 768, x4
 	li x4, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x1, csr_fail
+	#endif
 	li x4, 0x5a5a5a5a
 	csrrs x1, 768, x4
 	li x4, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x1, csr_fail
+	#endif
 	li x4, 0x2b045e01
 	csrrs x1, 768, x4
 	li x4, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x1, csr_fail
+	#endif
 	li x4, 0xa5a5a5a5
 	csrrc x1, 768, x4
 	li x4, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x1, csr_fail
+	#endif
 	li x4, 0x5a5a5a5a
 	csrrc x1, 768, x4
 	li x4, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x1, csr_fail
+	#endif
 	li x4, 0x42ff4fc9
 	csrrc x1, 768, x4
 	li x4, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x1, csr_fail
+	#endif
 	csrrwi x1, 768, 0b00101
 	li x4, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x1, csr_fail
+	#endif
 	csrrwi x1, 768, 0b11010
 	li x4, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x1, csr_fail
+	#endif
 	csrrwi x1, 768, 0b11101
 	li x4, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x1, csr_fail
+	#endif
 	csrrsi x1, 768, 0b00101
 	li x4, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x1, csr_fail
+	#endif
 	csrrsi x1, 768, 0b11010
 	li x4, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x1, csr_fail
+	#endif
 	csrrsi x1, 768, 0b11010
 	li x4, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x1, csr_fail
+	#endif
 	csrrci x1, 768, 0b00101
 	li x4, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x1, csr_fail
+	#endif
 	csrrci x1, 768, 0b11010
 	li x4, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x1, csr_fail
+	#endif
 	csrrci x1, 768, 0b11111
 	li x4, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x1, csr_fail
+	#endif
 	# misa
 	li x4, 0xa5a5a5a5
 	csrrw x1, 769, x4
@@ -36862,66 +37848,102 @@ _start28:
 	li x8, 0xa5a5a5a5
 	csrrw x9, 768, x8
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x9, csr_fail
+	#endif
 	li x8, 0x5a5a5a5a
 	csrrw x9, 768, x8
 	li x8, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x9, csr_fail
+	#endif
 	li x8, 0xe09dcf14
 	csrrw x9, 768, x8
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x9, csr_fail
+	#endif
 	li x8, 0xa5a5a5a5
 	csrrs x9, 768, x8
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x9, csr_fail
+	#endif
 	li x8, 0x5a5a5a5a
 	csrrs x9, 768, x8
 	li x8, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x9, csr_fail
+	#endif
 	li x8, 0x77d56a3f
 	csrrs x9, 768, x8
 	li x8, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x9, csr_fail
+	#endif
 	li x8, 0xa5a5a5a5
 	csrrc x9, 768, x8
 	li x8, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x9, csr_fail
+	#endif
 	li x8, 0x5a5a5a5a
 	csrrc x9, 768, x8
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x9, csr_fail
+	#endif
 	li x8, 0xb88d8aa4
 	csrrc x9, 768, x8
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x9, csr_fail
+	#endif
 	csrrwi x9, 768, 0b00101
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x9, csr_fail
+	#endif
 	csrrwi x9, 768, 0b11010
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x9, csr_fail
+	#endif
 	csrrwi x9, 768, 0b01100
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x9, csr_fail
+	#endif
 	csrrsi x9, 768, 0b00101
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x9, csr_fail
+	#endif
 	csrrsi x9, 768, 0b11010
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x9, csr_fail
+	#endif
 	csrrsi x9, 768, 0b11010
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x9, csr_fail
+	#endif
 	csrrci x9, 768, 0b00101
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x9, csr_fail
+	#endif
 	csrrci x9, 768, 0b11010
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x9, csr_fail
+	#endif
 	csrrci x9, 768, 0b11100
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x9, csr_fail
+	#endif
 	# misa
 	li x8, 0xa5a5a5a5
 	csrrw x9, 769, x8
@@ -38159,66 +39181,102 @@ _start29:
 	li x4, 0xa5a5a5a5
 	csrrw x6, 768, x4
 	li x4, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x6, csr_fail
+	#endif
 	li x4, 0x5a5a5a5a
 	csrrw x6, 768, x4
 	li x4, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x6, csr_fail
+	#endif
 	li x4, 0x34168d30
 	csrrw x6, 768, x4
 	li x4, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x6, csr_fail
+	#endif
 	li x4, 0xa5a5a5a5
 	csrrs x6, 768, x4
 	li x4, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x6, csr_fail
+	#endif
 	li x4, 0x5a5a5a5a
 	csrrs x6, 768, x4
 	li x4, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x6, csr_fail
+	#endif
 	li x4, 0x9b0e3263
 	csrrs x6, 768, x4
 	li x4, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x6, csr_fail
+	#endif
 	li x4, 0xa5a5a5a5
 	csrrc x6, 768, x4
 	li x4, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x6, csr_fail
+	#endif
 	li x4, 0x5a5a5a5a
 	csrrc x6, 768, x4
 	li x4, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x6, csr_fail
+	#endif
 	li x4, 0xa7ae12e7
 	csrrc x6, 768, x4
 	li x4, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x6, csr_fail
+	#endif
 	csrrwi x6, 768, 0b00101
 	li x4, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x6, csr_fail
+	#endif
 	csrrwi x6, 768, 0b11010
 	li x4, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x6, csr_fail
+	#endif
 	csrrwi x6, 768, 0b10010
 	li x4, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x6, csr_fail
+	#endif
 	csrrsi x6, 768, 0b00101
 	li x4, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x6, csr_fail
+	#endif
 	csrrsi x6, 768, 0b11010
 	li x4, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x6, csr_fail
+	#endif
 	csrrsi x6, 768, 0b11110
 	li x4, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x6, csr_fail
+	#endif
 	csrrci x6, 768, 0b00101
 	li x4, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x6, csr_fail
+	#endif
 	csrrci x6, 768, 0b11010
 	li x4, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x6, csr_fail
+	#endif
 	csrrci x6, 768, 0b01001
 	li x4, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x6, csr_fail
+	#endif
 	# misa
 	li x4, 0xa5a5a5a5
 	csrrw x6, 769, x4
@@ -39456,66 +40514,102 @@ _start30:
 	li x4, 0xa5a5a5a5
 	csrrw x10, 768, x4
 	li x4, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x10, csr_fail
+	#endif
 	li x4, 0x5a5a5a5a
 	csrrw x10, 768, x4
 	li x4, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x10, csr_fail
+	#endif
 	li x4, 0xa6705d8b
 	csrrw x10, 768, x4
 	li x4, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x10, csr_fail
+	#endif
 	li x4, 0xa5a5a5a5
 	csrrs x10, 768, x4
 	li x4, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x10, csr_fail
+	#endif
 	li x4, 0x5a5a5a5a
 	csrrs x10, 768, x4
 	li x4, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x10, csr_fail
+	#endif
 	li x4, 0x3fbb2441
 	csrrs x10, 768, x4
 	li x4, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x10, csr_fail
+	#endif
 	li x4, 0xa5a5a5a5
 	csrrc x10, 768, x4
 	li x4, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x10, csr_fail
+	#endif
 	li x4, 0x5a5a5a5a
 	csrrc x10, 768, x4
 	li x4, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x10, csr_fail
+	#endif
 	li x4, 0xd9ee192e
 	csrrc x10, 768, x4
 	li x4, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x10, csr_fail
+	#endif
 	csrrwi x10, 768, 0b00101
 	li x4, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x10, csr_fail
+	#endif
 	csrrwi x10, 768, 0b11010
 	li x4, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x10, csr_fail
+	#endif
 	csrrwi x10, 768, 0b11010
 	li x4, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x10, csr_fail
+	#endif
 	csrrsi x10, 768, 0b00101
 	li x4, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x10, csr_fail
+	#endif
 	csrrsi x10, 768, 0b11010
 	li x4, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x10, csr_fail
+	#endif
 	csrrsi x10, 768, 0b00111
 	li x4, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x10, csr_fail
+	#endif
 	csrrci x10, 768, 0b00101
 	li x4, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x10, csr_fail
+	#endif
 	csrrci x10, 768, 0b11010
 	li x4, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x10, csr_fail
+	#endif
 	csrrci x10, 768, 0b00010
 	li x4, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x4, x10, csr_fail
+	#endif
 	# misa
 	li x4, 0xa5a5a5a5
 	csrrw x10, 769, x4
@@ -40753,66 +41847,102 @@ _start31:
 	li x8, 0xa5a5a5a5
 	csrrw x14, 768, x8
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x14, csr_fail
+	#endif
 	li x8, 0x5a5a5a5a
 	csrrw x14, 768, x8
 	li x8, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x14, csr_fail
+	#endif
 	li x8, 0x32245727
 	csrrw x14, 768, x8
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x14, csr_fail
+	#endif
 	li x8, 0xa5a5a5a5
 	csrrs x14, 768, x8
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x14, csr_fail
+	#endif
 	li x8, 0x5a5a5a5a
 	csrrs x14, 768, x8
 	li x8, 0x00001880
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x14, csr_fail
+	#endif
 	li x8, 0x7ddc0d5e
 	csrrs x14, 768, x8
 	li x8, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x14, csr_fail
+	#endif
 	li x8, 0xa5a5a5a5
 	csrrc x14, 768, x8
 	li x8, 0x00001888
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x14, csr_fail
+	#endif
 	li x8, 0x5a5a5a5a
 	csrrc x14, 768, x8
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x14, csr_fail
+	#endif
 	li x8, 0x3ec76a76
 	csrrc x14, 768, x8
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x14, csr_fail
+	#endif
 	csrrwi x14, 768, 0b00101
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x14, csr_fail
+	#endif
 	csrrwi x14, 768, 0b11010
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x14, csr_fail
+	#endif
 	csrrwi x14, 768, 0b00001
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x14, csr_fail
+	#endif
 	csrrsi x14, 768, 0b00101
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x14, csr_fail
+	#endif
 	csrrsi x14, 768, 0b11010
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x14, csr_fail
+	#endif
 	csrrsi x14, 768, 0b11101
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x14, csr_fail
+	#endif
 	csrrci x14, 768, 0b00101
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x14, csr_fail
+	#endif
 	csrrci x14, 768, 0b11010
 	li x8, 0x00001808
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x14, csr_fail
+	#endif
 	csrrci x14, 768, 0b01111
 	li x8, 0x00001800
+	#if !defined(FPU) || defined(ZFINX)
 	bne x8, x14, csr_fail
+	#endif
 	# misa
 	li x8, 0xa5a5a5a5
 	csrrw x14, 769, x8

--- a/cv32e40p/tests/programs/custom/cv32e40p_readonly_csr_access_test/cv32e40p_readonly_csr_access_test.S
+++ b/cv32e40p/tests/programs/custom/cv32e40p_readonly_csr_access_test/cv32e40p_readonly_csr_access_test.S
@@ -31,8 +31,12 @@
 
 #define TEST_PASS                      123456789
 #define TEST_FAIL                              1
-#define VIRT_PERIPH_STATUS_FLAG_ADDR  0x20000000 
+#define VIRT_PERIPH_STATUS_FLAG_ADDR  0x20000000
+#if defined(PULP)
+#define EXPECTED_ILLEGAL_INSTRUCTIONS         78
+#else
 #define EXPECTED_ILLEGAL_INSTRUCTIONS         80
+#endif
 
 main:
     li        t0, (0x1 << 3)
@@ -133,7 +137,11 @@ main:
 	csrrwi x0,  3859, 0x0a   # illegal instruction: attempt to write RO CSR
 
 	csrrc  x5,  3859, x0     # not illegal
+#if defined(FPU) || defined(PULP) || defined(CLUSTER)
+	li     x30, 0x00000001
+#else
 	li     x30, 0x00000000
+#endif
 	bne    x5,  x30, fail
 
     # mhartid
@@ -291,7 +299,7 @@ u_sw_irq_handler:
     csrrw x0, mepc, x27
     c.addi x31, 1
     mret
-    
+
 _exit:
     j _exit
 

--- a/cv32e40p/tests/programs/custom/generic_exception_test/generic_exception_test.S
+++ b/cv32e40p/tests/programs/custom/generic_exception_test/generic_exception_test.S
@@ -1,18 +1,18 @@
 #
 # Copyright (C) 2020 by EM Microelectronic US Inc.
-# 
+#
 # Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     https://solderpad.org/licenses/
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 #
 ###############################################################################
@@ -24,10 +24,10 @@
 #
 # The pass/fail criteria is determined by checking x26 against MAGIC_NUMBER,
 # the value of which is determined by summing the following:
-#    - Exception code  2 (Illegal Instruction Exceptions (IIE)): 0x1 
-#    - Exception code  3 (Breakpoint):                           0x10
-#    - Exception code 11 (Environment call):                     0x100
-# If the test has one of each exception code, MAGIC_NUMBER is 0x111
+#    - Exception code  2 (Illegal Instruction Exceptions (IIE)): 0x1
+#    - Exception code  3 (Breakpoint):                           0x100
+#    - Exception code 11 (Environment call):                     0x1000
+# If the test has one of each exception code, MAGIC_NUMBER is 0x11001. It allows up to 255 IIE
 #
 ###############################################################################
 
@@ -39,7 +39,12 @@
 .global test_results
 .global u_sw_irq_handler
 
-    #define MAGIC_NUMBER 0x2f3
+# there are 2 env calls in the code
+# there are 5 breakpoints in the code
+# there are 129 unknown encodings (minus 2 because of 2 last instructions unused fields in fence), 2 unimp corresponding to .word 00000000, 1 (uret), 29 illegal CSR access = 9d
+# For FPU-enabled configuration, letting mstatus_FS at default value lead to the same number of illegal instrucions
+
+#define MAGIC_NUMBER 0x259d
 
 test_results:
 	.word 123456789
@@ -208,15 +213,15 @@ main:
     csrrc x14, mstatus, x0
     nop
     nop
- 
+
 added_by_mike:
 ###############################################################################
-# Randomly generated illegal instructions.  Each one adds 0x1 to MAGIC_NUMBER
+# Randomly generated illegal instructions.  Each one adds 0x1 to MAGIC_NUMBER (except for v2 and the one mentionned below that are legal encodings)
     .word(0x3bc6f92f)
     .word(0x5dd26da7)
     .word(0xe5607a57)
     .word(0x958e4a67)
-    .word(0x6159607b)
+    .word(0x6159607b) # for v2 it corresponds to cv.xor.sci.h	zero,s2,-22 (not illegal anymore)
     .word(0x6c6b7433)
     .word(0x1a6a2b33)
     .word(0xd9067c3b)
@@ -231,7 +236,7 @@ added_by_mike:
     .word(0x5dd26da7)
     .word(0xe5607a57)
     .word(0x958e4a67)
-    .word(0x6159607b)
+    .word(0x6159607b) # for v2 it corresponds to cv.xor.sci.h	zero,s2,-22 (not illegal anymore)
     .word(0x6c6b7433)
     .word(0x1a6a2b33)
     .word(0xd9067c3b)
@@ -240,7 +245,7 @@ added_by_mike:
     .word(0x6fcbc273)
     .word(0x395dd7e7)
     .word(0x079f0c07)
-#
+
     .word(0x57f0f043)
     .word(0xc06d0abb)
     .word(0x75d8b2fb)
@@ -257,7 +262,7 @@ added_by_mike:
     .word(0x1d4d43ab)
     .word(0xb7aecccf)
     .word(0x1ac1e077)
-#
+
     .word(0x25ffc977)
     .word(0xceb61647)
     .word(0x4284de0f)
@@ -274,21 +279,21 @@ added_by_mike:
     .word(0xc964b70f)
     .word(0x58ff393b)
     .word(0xaf9ac3a7)
-#
+
     .word(0x70f6bf03)
     .word(0x9da18a53)
     .word(0x6738ef8f)
-    .word(0xf4f4ba5b)
+    .word(0xf4f4ba5b) # for v2 it corresponds to cv.suburn	s4,s1,a5,26 (not illegal anymore)
     .word(0xb4208057)
     .word(0x72857967)
     .word(0x64599d9b)
     .word(0x7328b2bb)
     .word(0x9fddb933)
-    .word(0x60628efb)
+    .word(0x60628efb) # for v2 it corresponds to cv.xor.h	t4,t0,t1 (not illegal anymore)
     .word(0xaec951bb)
     .word(0xc56f4a27)
     .word(0x2e266467)
-    .word(0xa847620b)
+    .word(0xa847620b) # for v2 it corresponds to cv.beqimm	a4,4,fffff5b0 <debug+0xfffff044> (not illegal anymore)
     .word(0x5dd26c27)
     .word(0xb8ba7523)
 #
@@ -307,7 +312,7 @@ added_by_mike:
     .word(0x427706f7)
     .word(0xbcd64e2f)
     .word(0x17f9256b)
-    .word(0x4c9cb05b)
+    .word(0x4c9cb05b) # for v2 it corresponds to cv.subun	zero,s9,s1,6 (not illegal anymore)
 #
     .word(0x2ec14d9b)
     .word(0x974ffc9b)
@@ -369,24 +374,24 @@ added_by_mike:
     csrrw x0, 0x040, x0 #USCRATCH
     csrrw x0, 0x043, x0 #UTVAL
     csrrw x0, 0x044, x0 #UIP
-# p.elw
-    .word(0x00006003)   # add 0x1 to MAGIC_NUMBER
-    .word(0x00106003)   # add 0x1 to MAGIC_NUMBER
-    .word(0x00206003)   # add 0x1 to MAGIC_NUMBER
-    .word(0x00406003)   # add 0x1 to MAGIC_NUMBER
-    .word(0x00806003)   # add 0x1 to MAGIC_NUMBER
-    .word(0x01006003)   # add 0x1 to MAGIC_NUMBER
+# cv.elw
+    .word(0x0000300B)   # add 0x1 to MAGIC_NUMBER
+    .word(0x0000308B)   # add 0x1 to MAGIC_NUMBER
+    .word(0x0000310B)   # add 0x1 to MAGIC_NUMBER
+    .word(0x0000320B)   # add 0x1 to MAGIC_NUMBER
+    .word(0x0000340B)   # add 0x1 to MAGIC_NUMBER
+    .word(0x0000380B)   # add 0x1 to MAGIC_NUMBER
 # uret
     uret                # add 0x1 to MAGIC_NUMBER
-# p.elw
-    .word(0x02006003)   # add 0x1 to MAGIC_NUMBER
-    .word(0x04006003)   # add 0x1 to MAGIC_NUMBER
-    .word(0x08006003)   # add 0x1 to MAGIC_NUMBER
-    .word(0x10006003)   # add 0x1 to MAGIC_NUMBER
-    .word(0x20006003)   # add 0x1 to MAGIC_NUMBER
-    .word(0x40006003)   # add 0x1 to MAGIC_NUMBER
-    .word(0x80006003)   # add 0x1 to MAGIC_NUMBER
-# unused fields in fence (these should _not_ add to MAGIC_NUMBER
+# cv.elw
+    .word(0x0000B00B)   # add 0x1 to MAGIC_NUMBER
+    .word(0x0000300B)   # add 0x1 to MAGIC_NUMBER
+    .word(0x0001300B)   # add 0x1 to MAGIC_NUMBER
+    .word(0x0002300B)   # add 0x1 to MAGIC_NUMBER
+    .word(0x0004300B)   # add 0x1 to MAGIC_NUMBER
+    .word(0x0008300B)   # add 0x1 to MAGIC_NUMBER
+    .word(0x0010300B)   # add 0x1 to MAGIC_NUMBER
+# unused fields in fence (these should _not_ add to MAGIC_NUMBER)
     .word(0x00000F8F)   # rd/imm5  =0b11111
     .word(0x000F800F)   # rs1 =0b11111
 exit:
@@ -449,7 +454,8 @@ continue_check:
 _check_3:
     li t4, 3
     bne t6, t4, _check_11
-    addi x26, x26, 0x10 # ebreak: add 0x10 to x26
+    li x29, 0x100
+    add x26, x26, x29 # ebreak: add 0x100 to x26
     csrrc s0, mepc, x0
     c.addi s0, 2
     csrrw x0, mepc, s0
@@ -457,7 +463,8 @@ _check_3:
 _check_11:
     li t4, 11
     bne t6, t4, _end_trap_Generic_Handler_ASM
-    addi x26, x26, 0x100 # ecall: add 0x100 to x26
+    li x29, 0x1000
+    add x26, x26, x29 # ecall: add 0x1000 to x26
     csrrc s0, mepc, x0
     c.addi s0, 4
     csrrw x0, mepc, s0
@@ -493,7 +500,7 @@ _end_trap_Generic_Handler_ASM:
     lw      x31,4(sp)
     addi    sp,sp,120
     mret
-    
+
 _exit:
     j _exit
 

--- a/cv32e40p/tests/programs/custom/mhpmcounter29_csr_access_test_1/mhpmcounter29_csr_access_test_1.S
+++ b/cv32e40p/tests/programs/custom/mhpmcounter29_csr_access_test_1/mhpmcounter29_csr_access_test_1.S
@@ -34,8 +34,14 @@
 
 #define TEST_PASS                      123456789
 #define TEST_FAIL                              1
-#define VIRT_PERIPH_STATUS_FLAG_ADDR  0x20000000 
+#define VIRT_PERIPH_STATUS_FLAG_ADDR  0x20000000
 #define EXPECTED_ILLEGAL_INSTRUCTIONS         24
+
+#if defined(FPU) || defined(PULP) || defined(CLUSTER)
+#define MIMPID_RESET_VALUE 0x00000001
+#else
+#define MIMPID_RESET_VALUE 0x00000000
+#endif
 
 main:
     li        t0, (0x1 << 3)
@@ -102,282 +108,282 @@ main:
 
 	# mhpmevent4
 	csrrci x5,  0x324, 0x0a
-	csrrc  x5,  0x324, x0  
-	csrrc  x0,  0x324, x5  
+	csrrc  x5,  0x324, x0
+	csrrc  x0,  0x324, x5
 	csrrci x5,  0x324, 0x0a
-	csrrs  x0,  0x324, x5  
+	csrrs  x0,  0x324, x5
  	csrrsi x0,  0x324, 0x0a
- 	csrrw  x0,  0x324, x0  
+ 	csrrw  x0,  0x324, x0
 	csrrwi x0,  0x324, 0x0a
 
 	# mhpmevent5
 	csrrci x5,  0x325, 0x0a
-	csrrc  x5,  0x325, x0  
-	csrrc  x0,  0x325, x5  
+	csrrc  x5,  0x325, x0
+	csrrc  x0,  0x325, x5
 	csrrci x5,  0x325, 0x0a
-	csrrs  x0,  0x325, x5  
+	csrrs  x0,  0x325, x5
  	csrrsi x0,  0x325, 0x0a
- 	csrrw  x0,  0x325, x0  
+ 	csrrw  x0,  0x325, x0
 	csrrwi x0,  0x325, 0x0a
 
 	# mhpmevent6
 	csrrci x5,  0x326, 0x0a
-	csrrc  x5,  0x326, x0  
-	csrrc  x0,  0x326, x5  
+	csrrc  x5,  0x326, x0
+	csrrc  x0,  0x326, x5
 	csrrci x5,  0x326, 0x0a
-	csrrs  x0,  0x326, x5  
+	csrrs  x0,  0x326, x5
  	csrrsi x0,  0x326, 0x0a
- 	csrrw  x0,  0x326, x0  
+ 	csrrw  x0,  0x326, x0
 	csrrwi x0,  0x326, 0x0a
 
 	# mhpmevent7
 	csrrci x5,  0x327, 0x0a
-	csrrc  x5,  0x327, x0  
-	csrrc  x0,  0x327, x5  
+	csrrc  x5,  0x327, x0
+	csrrc  x0,  0x327, x5
 	csrrci x5,  0x327, 0x0a
-	csrrs  x0,  0x327, x5  
+	csrrs  x0,  0x327, x5
  	csrrsi x0,  0x327, 0x0a
- 	csrrw  x0,  0x327, x0  
+ 	csrrw  x0,  0x327, x0
 	csrrwi x0,  0x327, 0x0a
 
 	# mhpmevent8
 	csrrci x5,  0x328, 0x0a
-	csrrc  x5,  0x328, x0  
-	csrrc  x0,  0x328, x5  
+	csrrc  x5,  0x328, x0
+	csrrc  x0,  0x328, x5
 	csrrci x5,  0x328, 0x0a
-	csrrs  x0,  0x328, x5  
+	csrrs  x0,  0x328, x5
  	csrrsi x0,  0x328, 0x0a
- 	csrrw  x0,  0x328, x0  
+ 	csrrw  x0,  0x328, x0
 	csrrwi x0,  0x328, 0x0a
 
 	# mhpmevent9
 	csrrci x5,  0x329, 0x0a
-	csrrc  x5,  0x329, x0  
-	csrrc  x0,  0x329, x5  
+	csrrc  x5,  0x329, x0
+	csrrc  x0,  0x329, x5
 	csrrci x5,  0x329, 0x0a
-	csrrs  x0,  0x329, x5  
+	csrrs  x0,  0x329, x5
  	csrrsi x0,  0x329, 0x0a
- 	csrrw  x0,  0x329, x0  
+ 	csrrw  x0,  0x329, x0
 	csrrwi x0,  0x329, 0x0a
 
 	# mhpmevent10
 	csrrci x5,  0x32a, 0x0a
-	csrrc  x5,  0x32a, x0  
-	csrrc  x0,  0x32a, x5  
+	csrrc  x5,  0x32a, x0
+	csrrc  x0,  0x32a, x5
 	csrrci x5,  0x32a, 0x0a
-	csrrs  x0,  0x32a, x5  
+	csrrs  x0,  0x32a, x5
  	csrrsi x0,  0x32a, 0x0a
- 	csrrw  x0,  0x32a, x0  
+ 	csrrw  x0,  0x32a, x0
 	csrrwi x0,  0x32a, 0x0a
 
 	# mhpmevent11
 	csrrci x5,  0x32b, 0x0a
-	csrrc  x5,  0x32b, x0  
-	csrrc  x0,  0x32b, x5  
+	csrrc  x5,  0x32b, x0
+	csrrc  x0,  0x32b, x5
 	csrrci x5,  0x32b, 0x0a
-	csrrs  x0,  0x32b, x5  
+	csrrs  x0,  0x32b, x5
  	csrrsi x0,  0x32b, 0x0a
- 	csrrw  x0,  0x32b, x0  
+ 	csrrw  x0,  0x32b, x0
 	csrrwi x0,  0x32b, 0x0a
 
 	# mhpmevent12
 	csrrci x5,  0x32c, 0x0a
-	csrrc  x5,  0x32c, x0  
-	csrrc  x0,  0x32c, x5  
+	csrrc  x5,  0x32c, x0
+	csrrc  x0,  0x32c, x5
 	csrrci x5,  0x32c, 0x0a
-	csrrs  x0,  0x32c, x5  
+	csrrs  x0,  0x32c, x5
  	csrrsi x0,  0x32c, 0x0a
- 	csrrw  x0,  0x32c, x0  
+ 	csrrw  x0,  0x32c, x0
 	csrrwi x0,  0x32c, 0x0a
 
 	# mhpmevent13
 	csrrci x5,  0x32d, 0x0a
-	csrrc  x5,  0x32d, x0  
-	csrrc  x0,  0x32d, x5  
+	csrrc  x5,  0x32d, x0
+	csrrc  x0,  0x32d, x5
 	csrrci x5,  0x32d, 0x0a
-	csrrs  x0,  0x32d, x5  
+	csrrs  x0,  0x32d, x5
  	csrrsi x0,  0x32d, 0x0a
- 	csrrw  x0,  0x32d, x0  
+ 	csrrw  x0,  0x32d, x0
 	csrrwi x0,  0x32d, 0x0a
 
 	# mhpmevent14
 	csrrci x5,  0x32e, 0x0a
-	csrrc  x5,  0x32e, x0  
-	csrrc  x0,  0x32e, x5  
+	csrrc  x5,  0x32e, x0
+	csrrc  x0,  0x32e, x5
 	csrrci x5,  0x32e, 0x0a
-	csrrs  x0,  0x32e, x5  
+	csrrs  x0,  0x32e, x5
  	csrrsi x0,  0x32e, 0x0a
- 	csrrw  x0,  0x32e, x0  
+ 	csrrw  x0,  0x32e, x0
 	csrrwi x0,  0x32e, 0x0a
 
 	# mhpmevent15
 	csrrci x5,  0x32f, 0x0a
-	csrrc  x5,  0x32f, x0  
-	csrrc  x0,  0x32f, x5  
+	csrrc  x5,  0x32f, x0
+	csrrc  x0,  0x32f, x5
 	csrrci x5,  0x32f, 0x0a
-	csrrs  x0,  0x32f, x5  
+	csrrs  x0,  0x32f, x5
  	csrrsi x0,  0x32f, 0x0a
- 	csrrw  x0,  0x32f, x0  
+ 	csrrw  x0,  0x32f, x0
 	csrrwi x0,  0x32f, 0x0a
 
 	# mhpmevent16
 	csrrci x5,  0x330, 0x0a
-	csrrc  x5,  0x330, x0  
-	csrrc  x0,  0x330, x5  
+	csrrc  x5,  0x330, x0
+	csrrc  x0,  0x330, x5
 	csrrci x5,  0x330, 0x0a
-	csrrs  x0,  0x330, x5  
+	csrrs  x0,  0x330, x5
  	csrrsi x0,  0x330, 0x0a
- 	csrrw  x0,  0x330, x0  
+ 	csrrw  x0,  0x330, x0
 	csrrwi x0,  0x330, 0x0a
 
 	# mhpmevent17
 	csrrci x5,  0x331, 0x0a
-	csrrc  x5,  0x331, x0  
-	csrrc  x0,  0x331, x5  
+	csrrc  x5,  0x331, x0
+	csrrc  x0,  0x331, x5
 	csrrci x5,  0x331, 0x0a
-	csrrs  x0,  0x331, x5  
+	csrrs  x0,  0x331, x5
  	csrrsi x0,  0x331, 0x0a
- 	csrrw  x0,  0x331, x0  
+ 	csrrw  x0,  0x331, x0
 	csrrwi x0,  0x331, 0x0a
 
 	# mhpmevent18
 	csrrci x5,  0x332, 0x0a
-	csrrc  x5,  0x332, x0  
-	csrrc  x0,  0x332, x5  
+	csrrc  x5,  0x332, x0
+	csrrc  x0,  0x332, x5
 	csrrci x5,  0x332, 0x0a
-	csrrs  x0,  0x332, x5  
+	csrrs  x0,  0x332, x5
  	csrrsi x0,  0x332, 0x0a
- 	csrrw  x0,  0x332, x0  
+ 	csrrw  x0,  0x332, x0
 	csrrwi x0,  0x332, 0x0a
 
 	# mhpmevent19
 	csrrci x5,  0x333, 0x0a
-	csrrc  x5,  0x333, x0  
-	csrrc  x0,  0x333, x5  
+	csrrc  x5,  0x333, x0
+	csrrc  x0,  0x333, x5
 	csrrci x5,  0x333, 0x0a
-	csrrs  x0,  0x333, x5  
+	csrrs  x0,  0x333, x5
  	csrrsi x0,  0x333, 0x0a
- 	csrrw  x0,  0x333, x0  
+ 	csrrw  x0,  0x333, x0
 	csrrwi x0,  0x333, 0x0a
 
 	# mhpmevent20
 	csrrci x5,  0x334, 0x0a
-	csrrc  x5,  0x334, x0  
-	csrrc  x0,  0x334, x5  
+	csrrc  x5,  0x334, x0
+	csrrc  x0,  0x334, x5
 	csrrci x5,  0x334, 0x0a
-	csrrs  x0,  0x334, x5  
+	csrrs  x0,  0x334, x5
  	csrrsi x0,  0x334, 0x0a
- 	csrrw  x0,  0x334, x0  
+ 	csrrw  x0,  0x334, x0
 	csrrwi x0,  0x334, 0x0a
 
 	# mhpmevent21
 	csrrci x5,  0x335, 0x0a
-	csrrc  x5,  0x335, x0  
-	csrrc  x0,  0x335, x5  
+	csrrc  x5,  0x335, x0
+	csrrc  x0,  0x335, x5
 	csrrci x5,  0x335, 0x0a
-	csrrs  x0,  0x335, x5  
+	csrrs  x0,  0x335, x5
  	csrrsi x0,  0x335, 0x0a
- 	csrrw  x0,  0x335, x0  
+ 	csrrw  x0,  0x335, x0
 	csrrwi x0,  0x335, 0x0a
 
 	# mhpmevent22
 	csrrci x5,  0x336, 0x0a
-	csrrc  x5,  0x336, x0  
-	csrrc  x0,  0x336, x5  
+	csrrc  x5,  0x336, x0
+	csrrc  x0,  0x336, x5
 	csrrci x5,  0x336, 0x0a
-	csrrs  x0,  0x336, x5  
+	csrrs  x0,  0x336, x5
  	csrrsi x0,  0x336, 0x0a
- 	csrrw  x0,  0x336, x0  
+ 	csrrw  x0,  0x336, x0
 	csrrwi x0,  0x336, 0x0a
 
 	# mhpmevent23
 	csrrci x5,  0x337, 0x0a
-	csrrc  x5,  0x337, x0  
-	csrrc  x0,  0x337, x5  
+	csrrc  x5,  0x337, x0
+	csrrc  x0,  0x337, x5
 	csrrci x5,  0x337, 0x0a
-	csrrs  x0,  0x337, x5  
+	csrrs  x0,  0x337, x5
  	csrrsi x0,  0x337, 0x0a
- 	csrrw  x0,  0x337, x0  
+ 	csrrw  x0,  0x337, x0
 	csrrwi x0,  0x337, 0x0a
 
 	# mhpmevent24
 	csrrci x5,  0x338, 0x0a
-	csrrc  x5,  0x338, x0  
-	csrrc  x0,  0x338, x5  
+	csrrc  x5,  0x338, x0
+	csrrc  x0,  0x338, x5
 	csrrci x5,  0x338, 0x0a
-	csrrs  x0,  0x338, x5  
+	csrrs  x0,  0x338, x5
  	csrrsi x0,  0x338, 0x0a
- 	csrrw  x0,  0x338, x0  
+ 	csrrw  x0,  0x338, x0
 	csrrwi x0,  0x338, 0x0a
 
 	# mhpmevent25
 	csrrci x5,  0x339, 0x0a
-	csrrc  x5,  0x339, x0  
-	csrrc  x0,  0x339, x5  
+	csrrc  x5,  0x339, x0
+	csrrc  x0,  0x339, x5
 	csrrci x5,  0x339, 0x0a
-	csrrs  x0,  0x339, x5  
+	csrrs  x0,  0x339, x5
  	csrrsi x0,  0x339, 0x0a
- 	csrrw  x0,  0x339, x0  
+ 	csrrw  x0,  0x339, x0
 	csrrwi x0,  0x339, 0x0a
 
 	# mhpmevent26
 	csrrci x5,  0x33a, 0x0a
-	csrrc  x5,  0x33a, x0  
-	csrrc  x0,  0x33a, x5  
+	csrrc  x5,  0x33a, x0
+	csrrc  x0,  0x33a, x5
 	csrrci x5,  0x33a, 0x0a
-	csrrs  x0,  0x33a, x5  
+	csrrs  x0,  0x33a, x5
  	csrrsi x0,  0x33a, 0x0a
- 	csrrw  x0,  0x33a, x0  
+ 	csrrw  x0,  0x33a, x0
 	csrrwi x0,  0x33a, 0x0a
 
 	# mhpmevent27
 	csrrci x5,  0x33b, 0x0a
-	csrrc  x5,  0x33b, x0  
-	csrrc  x0,  0x33b, x5  
+	csrrc  x5,  0x33b, x0
+	csrrc  x0,  0x33b, x5
 	csrrci x5,  0x33b, 0x0a
-	csrrs  x0,  0x33b, x5  
+	csrrs  x0,  0x33b, x5
  	csrrsi x0,  0x33b, 0x0a
- 	csrrw  x0,  0x33b, x0  
+ 	csrrw  x0,  0x33b, x0
 	csrrwi x0,  0x33b, 0x0a
 
 	# mhpmevent28
 	csrrci x5,  0x33c, 0x0a
-	csrrc  x5,  0x33c, x0  
-	csrrc  x0,  0x33c, x5  
+	csrrc  x5,  0x33c, x0
+	csrrc  x0,  0x33c, x5
 	csrrci x5,  0x33c, 0x0a
-	csrrs  x0,  0x33c, x5  
+	csrrs  x0,  0x33c, x5
  	csrrsi x0,  0x33c, 0x0a
- 	csrrw  x0,  0x33c, x0  
+ 	csrrw  x0,  0x33c, x0
 	csrrwi x0,  0x33c, 0x0a
 
 	# mhpmevent29
 	csrrci x5,  0x33d, 0x0a
-	csrrc  x5,  0x33d, x0  
-	csrrc  x0,  0x33d, x5  
+	csrrc  x5,  0x33d, x0
+	csrrc  x0,  0x33d, x5
 	csrrci x5,  0x33d, 0x0a
-	csrrs  x0,  0x33d, x5  
+	csrrs  x0,  0x33d, x5
  	csrrsi x0,  0x33d, 0x0a
- 	csrrw  x0,  0x33d, x0  
+ 	csrrw  x0,  0x33d, x0
 	csrrwi x0,  0x33d, 0x0a
 
 	# mhpmevent30
 	csrrci x5,  0x33e, 0x0a
-	csrrc  x5,  0x33e, x0  
-	csrrc  x0,  0x33e, x5  
+	csrrc  x5,  0x33e, x0
+	csrrc  x0,  0x33e, x5
 	csrrci x5,  0x33e, 0x0a
-	csrrs  x0,  0x33e, x5  
+	csrrs  x0,  0x33e, x5
  	csrrsi x0,  0x33e, 0x0a
- 	csrrw  x0,  0x33e, x0  
+ 	csrrw  x0,  0x33e, x0
 	csrrwi x0,  0x33e, 0x0a
 
 	# mhpmevent31
 	csrrci x5,  0x33f, 0x0a
-	csrrc  x5,  0x33f, x0  
-	csrrc  x0,  0x33f, x5  
+	csrrc  x5,  0x33f, x0
+	csrrc  x0,  0x33f, x5
 	csrrci x5,  0x33f, 0x0a
-	csrrs  x0,  0x33f, x5  
+	csrrs  x0,  0x33f, x5
  	csrrsi x0,  0x33f, 0x0a
- 	csrrw  x0,  0x33f, x0  
+ 	csrrw  x0,  0x33f, x0
 	csrrwi x0,  0x33f, 0x0a
 
     ################
@@ -394,282 +400,282 @@ main:
 
 	# mhpmcounter4
 	csrrci x5,  0xB04, 0x0a
-	csrrc  x5,  0xB04, x0  
-	csrrc  x0,  0xB04, x5  
+	csrrc  x5,  0xB04, x0
+	csrrc  x0,  0xB04, x5
 	csrrci x5,  0xB04, 0x0a
-	csrrs  x0,  0xB04, x5  
+	csrrs  x0,  0xB04, x5
  	csrrsi x0,  0xB04, 0x0a
- 	csrrw  x0,  0xB04, x0  
+ 	csrrw  x0,  0xB04, x0
 	csrrwi x0,  0xB04, 0x0a
 
 	# mhpmcounter5
 	csrrci x5,  0xB05, 0x0a
-	csrrc  x5,  0xB05, x0  
-	csrrc  x0,  0xB05, x5  
+	csrrc  x5,  0xB05, x0
+	csrrc  x0,  0xB05, x5
 	csrrci x5,  0xB05, 0x0a
-	csrrs  x0,  0xB05, x5  
+	csrrs  x0,  0xB05, x5
  	csrrsi x0,  0xB05, 0x0a
- 	csrrw  x0,  0xB05, x0  
+ 	csrrw  x0,  0xB05, x0
 	csrrwi x0,  0xB05, 0x0a
 
 	# mhpmcounter6
 	csrrci x5,  0xB06, 0x0a
-	csrrc  x5,  0xB06, x0  
-	csrrc  x0,  0xB06, x5  
+	csrrc  x5,  0xB06, x0
+	csrrc  x0,  0xB06, x5
 	csrrci x5,  0xB06, 0x0a
-	csrrs  x0,  0xB06, x5  
+	csrrs  x0,  0xB06, x5
  	csrrsi x0,  0xB06, 0x0a
- 	csrrw  x0,  0xB06, x0  
+ 	csrrw  x0,  0xB06, x0
 	csrrwi x0,  0xB06, 0x0a
 
 	# mhpmcounter7
 	csrrci x5,  0xB07, 0x0a
-	csrrc  x5,  0xB07, x0  
-	csrrc  x0,  0xB07, x5  
+	csrrc  x5,  0xB07, x0
+	csrrc  x0,  0xB07, x5
 	csrrci x5,  0xB07, 0x0a
-	csrrs  x0,  0xB07, x5  
+	csrrs  x0,  0xB07, x5
  	csrrsi x0,  0xB07, 0x0a
- 	csrrw  x0,  0xB07, x0  
+ 	csrrw  x0,  0xB07, x0
 	csrrwi x0,  0xB07, 0x0a
 
 	# mhpmcounter8
 	csrrci x5,  0xB08, 0x0a
-	csrrc  x5,  0xB08, x0  
-	csrrc  x0,  0xB08, x5  
+	csrrc  x5,  0xB08, x0
+	csrrc  x0,  0xB08, x5
 	csrrci x5,  0xB08, 0x0a
-	csrrs  x0,  0xB08, x5  
+	csrrs  x0,  0xB08, x5
  	csrrsi x0,  0xB08, 0x0a
- 	csrrw  x0,  0xB08, x0  
+ 	csrrw  x0,  0xB08, x0
 	csrrwi x0,  0xB08, 0x0a
 
 	# mhpmcounter9
 	csrrci x5,  0xB09, 0x0a
-	csrrc  x5,  0xB09, x0  
-	csrrc  x0,  0xB09, x5  
+	csrrc  x5,  0xB09, x0
+	csrrc  x0,  0xB09, x5
 	csrrci x5,  0xB09, 0x0a
-	csrrs  x0,  0xB09, x5  
+	csrrs  x0,  0xB09, x5
  	csrrsi x0,  0xB09, 0x0a
- 	csrrw  x0,  0xB09, x0  
+ 	csrrw  x0,  0xB09, x0
 	csrrwi x0,  0xB09, 0x0a
 
 	# mhpmcounter10
 	csrrci x5,  0xB0A, 0x0a
-	csrrc  x5,  0xB0A, x0  
-	csrrc  x0,  0xB0A, x5  
+	csrrc  x5,  0xB0A, x0
+	csrrc  x0,  0xB0A, x5
 	csrrci x5,  0xB0A, 0x0a
-	csrrs  x0,  0xB0A, x5  
+	csrrs  x0,  0xB0A, x5
  	csrrsi x0,  0xB0A, 0x0a
- 	csrrw  x0,  0xB0A, x0  
+ 	csrrw  x0,  0xB0A, x0
 	csrrwi x0,  0xB0A, 0x0a
 
 	# mhpmcounter11
 	csrrci x5,  0xB0B, 0x0a
-	csrrc  x5,  0xB0B, x0  
-	csrrc  x0,  0xB0B, x5  
+	csrrc  x5,  0xB0B, x0
+	csrrc  x0,  0xB0B, x5
 	csrrci x5,  0xB0B, 0x0a
-	csrrs  x0,  0xB0B, x5  
+	csrrs  x0,  0xB0B, x5
  	csrrsi x0,  0xB0B, 0x0a
- 	csrrw  x0,  0xB0B, x0  
+ 	csrrw  x0,  0xB0B, x0
 	csrrwi x0,  0xB0B, 0x0a
 
 	# mhpmcounter12
 	csrrci x5,  0xB0C, 0x0a
-	csrrc  x5,  0xB0C, x0  
-	csrrc  x0,  0xB0C, x5  
+	csrrc  x5,  0xB0C, x0
+	csrrc  x0,  0xB0C, x5
 	csrrci x5,  0xB0C, 0x0a
-	csrrs  x0,  0xB0C, x5  
+	csrrs  x0,  0xB0C, x5
  	csrrsi x0,  0xB0C, 0x0a
- 	csrrw  x0,  0xB0C, x0  
+ 	csrrw  x0,  0xB0C, x0
 	csrrwi x0,  0xB0C, 0x0a
 
 	# mhpmcounter13
 	csrrci x5,  0xB0D, 0x0a
-	csrrc  x5,  0xB0D, x0  
-	csrrc  x0,  0xB0D, x5  
+	csrrc  x5,  0xB0D, x0
+	csrrc  x0,  0xB0D, x5
 	csrrci x5,  0xB0D, 0x0a
-	csrrs  x0,  0xB0D, x5  
+	csrrs  x0,  0xB0D, x5
  	csrrsi x0,  0xB0D, 0x0a
- 	csrrw  x0,  0xB0D, x0  
+ 	csrrw  x0,  0xB0D, x0
 	csrrwi x0,  0xB0D, 0x0a
 
 	# mhpmcounter14
 	csrrci x5,  0xB0E, 0x0a
-	csrrc  x5,  0xB0E, x0  
-	csrrc  x0,  0xB0E, x5  
+	csrrc  x5,  0xB0E, x0
+	csrrc  x0,  0xB0E, x5
 	csrrci x5,  0xB0E, 0x0a
-	csrrs  x0,  0xB0E, x5  
+	csrrs  x0,  0xB0E, x5
  	csrrsi x0,  0xB0E, 0x0a
- 	csrrw  x0,  0xB0E, x0  
+ 	csrrw  x0,  0xB0E, x0
 	csrrwi x0,  0xB0E, 0x0a
 
 	# mhpmcounter15
 	csrrci x5,  0xB0F, 0x0a
-	csrrc  x5,  0xB0F, x0  
-	csrrc  x0,  0xB0F, x5  
+	csrrc  x5,  0xB0F, x0
+	csrrc  x0,  0xB0F, x5
 	csrrci x5,  0xB0F, 0x0a
-	csrrs  x0,  0xB0F, x5  
+	csrrs  x0,  0xB0F, x5
  	csrrsi x0,  0xB0F, 0x0a
- 	csrrw  x0,  0xB0F, x0  
+ 	csrrw  x0,  0xB0F, x0
 	csrrwi x0,  0xB0F, 0x0a
 
 	# mhpmcounter16
 	csrrci x5,  0xB10, 0x0a
-	csrrc  x5,  0xB10, x0  
-	csrrc  x0,  0xB10, x5  
+	csrrc  x5,  0xB10, x0
+	csrrc  x0,  0xB10, x5
 	csrrci x5,  0xB10, 0x0a
-	csrrs  x0,  0xB10, x5  
+	csrrs  x0,  0xB10, x5
  	csrrsi x0,  0xB10, 0x0a
- 	csrrw  x0,  0xB10, x0  
+ 	csrrw  x0,  0xB10, x0
 	csrrwi x0,  0xB10, 0x0a
 
 	# mhpmcounter17
 	csrrci x5,  0xB11, 0x0a
-	csrrc  x5,  0xB11, x0  
-	csrrc  x0,  0xB11, x5  
+	csrrc  x5,  0xB11, x0
+	csrrc  x0,  0xB11, x5
 	csrrci x5,  0xB11, 0x0a
-	csrrs  x0,  0xB11, x5  
+	csrrs  x0,  0xB11, x5
  	csrrsi x0,  0xB11, 0x0a
- 	csrrw  x0,  0xB11, x0  
+ 	csrrw  x0,  0xB11, x0
 	csrrwi x0,  0xB11, 0x0a
 
 	# mhpmcounter18
 	csrrci x5,  0xB12, 0x0a
-	csrrc  x5,  0xB12, x0  
-	csrrc  x0,  0xB12, x5  
+	csrrc  x5,  0xB12, x0
+	csrrc  x0,  0xB12, x5
 	csrrci x5,  0xB12, 0x0a
-	csrrs  x0,  0xB12, x5  
+	csrrs  x0,  0xB12, x5
  	csrrsi x0,  0xB12, 0x0a
- 	csrrw  x0,  0xB12, x0  
+ 	csrrw  x0,  0xB12, x0
 	csrrwi x0,  0xB12, 0x0a
 
 	# mhpmcounter19
 	csrrci x5,  0xB13, 0x0a
-	csrrc  x5,  0xB13, x0  
-	csrrc  x0,  0xB13, x5  
+	csrrc  x5,  0xB13, x0
+	csrrc  x0,  0xB13, x5
 	csrrci x5,  0xB13, 0x0a
-	csrrs  x0,  0xB13, x5  
+	csrrs  x0,  0xB13, x5
  	csrrsi x0,  0xB13, 0x0a
- 	csrrw  x0,  0xB13, x0  
+ 	csrrw  x0,  0xB13, x0
 	csrrwi x0,  0xB13, 0x0a
 
 	# mhpmcounter20
 	csrrci x5,  0xB14, 0x0a
-	csrrc  x5,  0xB14, x0  
-	csrrc  x0,  0xB14, x5  
+	csrrc  x5,  0xB14, x0
+	csrrc  x0,  0xB14, x5
 	csrrci x5,  0xB14, 0x0a
-	csrrs  x0,  0xB14, x5  
+	csrrs  x0,  0xB14, x5
  	csrrsi x0,  0xB14, 0x0a
- 	csrrw  x0,  0xB14, x0  
+ 	csrrw  x0,  0xB14, x0
 	csrrwi x0,  0xB14, 0x0a
 
 	# mhpmcounter21
 	csrrci x5,  0xB15, 0x0a
-	csrrc  x5,  0xB15, x0  
-	csrrc  x0,  0xB15, x5  
+	csrrc  x5,  0xB15, x0
+	csrrc  x0,  0xB15, x5
 	csrrci x5,  0xB15, 0x0a
-	csrrs  x0,  0xB15, x5  
+	csrrs  x0,  0xB15, x5
  	csrrsi x0,  0xB15, 0x0a
- 	csrrw  x0,  0xB15, x0  
+ 	csrrw  x0,  0xB15, x0
 	csrrwi x0,  0xB15, 0x0a
 
 	# mhpmcounter22
 	csrrci x5,  0xB16, 0x0a
-	csrrc  x5,  0xB16, x0  
-	csrrc  x0,  0xB16, x5  
+	csrrc  x5,  0xB16, x0
+	csrrc  x0,  0xB16, x5
 	csrrci x5,  0xB16, 0x0a
-	csrrs  x0,  0xB16, x5  
+	csrrs  x0,  0xB16, x5
  	csrrsi x0,  0xB16, 0x0a
- 	csrrw  x0,  0xB16, x0  
+ 	csrrw  x0,  0xB16, x0
 	csrrwi x0,  0xB16, 0x0a
 
 	# mhpmcounter23
 	csrrci x5,  0xB17, 0x0a
-	csrrc  x5,  0xB17, x0  
-	csrrc  x0,  0xB17, x5  
+	csrrc  x5,  0xB17, x0
+	csrrc  x0,  0xB17, x5
 	csrrci x5,  0xB17, 0x0a
-	csrrs  x0,  0xB17, x5  
+	csrrs  x0,  0xB17, x5
  	csrrsi x0,  0xB17, 0x0a
- 	csrrw  x0,  0xB17, x0  
+ 	csrrw  x0,  0xB17, x0
 	csrrwi x0,  0xB17, 0x0a
 
 	# mhpmcounter24
 	csrrci x5,  0xB18, 0x0a
-	csrrc  x5,  0xB18, x0  
-	csrrc  x0,  0xB18, x5  
+	csrrc  x5,  0xB18, x0
+	csrrc  x0,  0xB18, x5
 	csrrci x5,  0xB18, 0x0a
-	csrrs  x0,  0xB18, x5  
+	csrrs  x0,  0xB18, x5
  	csrrsi x0,  0xB18, 0x0a
- 	csrrw  x0,  0xB18, x0  
+ 	csrrw  x0,  0xB18, x0
 	csrrwi x0,  0xB18, 0x0a
 
 	# mhpmcounter25
 	csrrci x5,  0xB19, 0x0a
-	csrrc  x5,  0xB19, x0  
-	csrrc  x0,  0xB19, x5  
+	csrrc  x5,  0xB19, x0
+	csrrc  x0,  0xB19, x5
 	csrrci x5,  0xB19, 0x0a
-	csrrs  x0,  0xB19, x5  
+	csrrs  x0,  0xB19, x5
  	csrrsi x0,  0xB19, 0x0a
- 	csrrw  x0,  0xB19, x0  
+ 	csrrw  x0,  0xB19, x0
 	csrrwi x0,  0xB19, 0x0a
 
 	# mhpmcounter26
 	csrrci x5,  0xB1A, 0x0a
-	csrrc  x5,  0xB1A, x0  
-	csrrc  x0,  0xB1A, x5  
+	csrrc  x5,  0xB1A, x0
+	csrrc  x0,  0xB1A, x5
 	csrrci x5,  0xB1A, 0x0a
-	csrrs  x0,  0xB1A, x5  
+	csrrs  x0,  0xB1A, x5
  	csrrsi x0,  0xB1A, 0x0a
- 	csrrw  x0,  0xB1A, x0  
+ 	csrrw  x0,  0xB1A, x0
 	csrrwi x0,  0xB1A, 0x0a
 
 	# mhpmcounter27
 	csrrci x5,  0xB1B, 0x0a
-	csrrc  x5,  0xB1B, x0  
-	csrrc  x0,  0xB1B, x5  
+	csrrc  x5,  0xB1B, x0
+	csrrc  x0,  0xB1B, x5
 	csrrci x5,  0xB1B, 0x0a
-	csrrs  x0,  0xB1B, x5  
+	csrrs  x0,  0xB1B, x5
  	csrrsi x0,  0xB1B, 0x0a
- 	csrrw  x0,  0xB1B, x0  
+ 	csrrw  x0,  0xB1B, x0
 	csrrwi x0,  0xB1B, 0x0a
 
 	# mhpmcounter28
 	csrrci x5,  0xB1C, 0x0a
-	csrrc  x5,  0xB1C, x0  
-	csrrc  x0,  0xB1C, x5  
+	csrrc  x5,  0xB1C, x0
+	csrrc  x0,  0xB1C, x5
 	csrrci x5,  0xB1C, 0x0a
-	csrrs  x0,  0xB1C, x5  
+	csrrs  x0,  0xB1C, x5
  	csrrsi x0,  0xB1C, 0x0a
- 	csrrw  x0,  0xB1C, x0  
+ 	csrrw  x0,  0xB1C, x0
 	csrrwi x0,  0xB1C, 0x0a
 
 	# mhpmcounter29
 	csrrci x5,  0xB1D, 0x0a
-	csrrc  x5,  0xB1D, x0  
-	csrrc  x0,  0xB1D, x5  
+	csrrc  x5,  0xB1D, x0
+	csrrc  x0,  0xB1D, x5
 	csrrci x5,  0xB1D, 0x0a
-	csrrs  x0,  0xB1D, x5  
+	csrrs  x0,  0xB1D, x5
  	csrrsi x0,  0xB1D, 0x0a
- 	csrrw  x0,  0xB1D, x0  
+ 	csrrw  x0,  0xB1D, x0
 	csrrwi x0,  0xB1D, 0x0a
 
 	# mhpmcounter30
 	csrrci x5,  0xB1E, 0x0a
-	csrrc  x5,  0xB1E, x0  
-	csrrc  x0,  0xB1E, x5  
+	csrrc  x5,  0xB1E, x0
+	csrrc  x0,  0xB1E, x5
 	csrrci x5,  0xB1E, 0x0a
-	csrrs  x0,  0xB1E, x5  
+	csrrs  x0,  0xB1E, x5
  	csrrsi x0,  0xB1E, 0x0a
- 	csrrw  x0,  0xB1E, x0  
+ 	csrrw  x0,  0xB1E, x0
 	csrrwi x0,  0xB1E, 0x0a
 
 	# mhpmcounter31
 	csrrci x5,  0xB1F, 0x0a
-	csrrc  x5,  0xB1F, x0  
-	csrrc  x0,  0xB1F, x5  
+	csrrc  x5,  0xB1F, x0
+	csrrc  x0,  0xB1F, x5
 	csrrci x5,  0xB1F, 0x0a
-	csrrs  x0,  0xB1F, x5  
+	csrrs  x0,  0xB1F, x5
  	csrrsi x0,  0xB1F, 0x0a
- 	csrrw  x0,  0xB1F, x0  
+ 	csrrw  x0,  0xB1F, x0
 	csrrwi x0,  0xB1F, 0x0a
 
     ################
@@ -696,272 +702,272 @@ main:
 
 	# mhpmcounterh5
 	csrrci x5,  0xB85, 0x0a
-	csrrc  x5,  0xB85, x0  
-	csrrc  x0,  0xB85, x5  
+	csrrc  x5,  0xB85, x0
+	csrrc  x0,  0xB85, x5
 	csrrci x5,  0xB85, 0x0a
-	csrrs  x0,  0xB85, x5  
+	csrrs  x0,  0xB85, x5
  	csrrsi x0,  0xB85, 0x0a
- 	csrrw  x0,  0xB85, x0  
+ 	csrrw  x0,  0xB85, x0
 	csrrwi x0,  0xB85, 0x0a
 
 	# mhpmcounterh6
 	csrrci x5,  0xB86, 0x0a
-	csrrc  x5,  0xB86, x0  
-	csrrc  x0,  0xB86, x5  
+	csrrc  x5,  0xB86, x0
+	csrrc  x0,  0xB86, x5
 	csrrci x5,  0xB86, 0x0a
-	csrrs  x0,  0xB86, x5  
+	csrrs  x0,  0xB86, x5
  	csrrsi x0,  0xB86, 0x0a
- 	csrrw  x0,  0xB86, x0  
+ 	csrrw  x0,  0xB86, x0
 	csrrwi x0,  0xB86, 0x0a
 
 	# mhpmcounterh7
 	csrrci x5,  0xB87, 0x0a
-	csrrc  x5,  0xB87, x0  
-	csrrc  x0,  0xB87, x5  
+	csrrc  x5,  0xB87, x0
+	csrrc  x0,  0xB87, x5
 	csrrci x5,  0xB87, 0x0a
-	csrrs  x0,  0xB87, x5  
+	csrrs  x0,  0xB87, x5
  	csrrsi x0,  0xB87, 0x0a
- 	csrrw  x0,  0xB87, x0  
+ 	csrrw  x0,  0xB87, x0
 	csrrwi x0,  0xB87, 0x0a
 
 	# mhpmcounterh8
 	csrrci x5,  0xB88, 0x0a
-	csrrc  x5,  0xB88, x0  
-	csrrc  x0,  0xB88, x5  
+	csrrc  x5,  0xB88, x0
+	csrrc  x0,  0xB88, x5
 	csrrci x5,  0xB88, 0x0a
-	csrrs  x0,  0xB88, x5  
+	csrrs  x0,  0xB88, x5
  	csrrsi x0,  0xB88, 0x0a
- 	csrrw  x0,  0xB88, x0  
+ 	csrrw  x0,  0xB88, x0
 	csrrwi x0,  0xB88, 0x0a
 
 	# mhpmcounterh9
 	csrrci x5,  0xB89, 0x0a
-	csrrc  x5,  0xB89, x0  
-	csrrc  x0,  0xB89, x5  
+	csrrc  x5,  0xB89, x0
+	csrrc  x0,  0xB89, x5
 	csrrci x5,  0xB89, 0x0a
-	csrrs  x0,  0xB89, x5  
+	csrrs  x0,  0xB89, x5
  	csrrsi x0,  0xB89, 0x0a
- 	csrrw  x0,  0xB89, x0  
+ 	csrrw  x0,  0xB89, x0
 	csrrwi x0,  0xB89, 0x0a
 
 	# mhpmcounterh10
 	csrrci x5,  0xB8A, 0x0a
-	csrrc  x5,  0xB8A, x0  
-	csrrc  x0,  0xB8A, x5  
+	csrrc  x5,  0xB8A, x0
+	csrrc  x0,  0xB8A, x5
 	csrrci x5,  0xB8A, 0x0a
-	csrrs  x0,  0xB8A, x5  
+	csrrs  x0,  0xB8A, x5
  	csrrsi x0,  0xB8A, 0x0a
- 	csrrw  x0,  0xB8A, x0  
+ 	csrrw  x0,  0xB8A, x0
 	csrrwi x0,  0xB8A, 0x0a
 
 	# mhpmcounterh11
 	csrrci x5,  0xB8B, 0x0a
-	csrrc  x5,  0xB8B, x0  
-	csrrc  x0,  0xB8B, x5  
+	csrrc  x5,  0xB8B, x0
+	csrrc  x0,  0xB8B, x5
 	csrrci x5,  0xB8B, 0x0a
-	csrrs  x0,  0xB8B, x5  
+	csrrs  x0,  0xB8B, x5
  	csrrsi x0,  0xB8B, 0x0a
- 	csrrw  x0,  0xB8B, x0  
+ 	csrrw  x0,  0xB8B, x0
 	csrrwi x0,  0xB8B, 0x0a
 
 	# mhpmcounterh12
 	csrrci x5,  0xB8C, 0x0a
-	csrrc  x5,  0xB8C, x0  
-	csrrc  x0,  0xB8C, x5  
+	csrrc  x5,  0xB8C, x0
+	csrrc  x0,  0xB8C, x5
 	csrrci x5,  0xB8C, 0x0a
-	csrrs  x0,  0xB8C, x5  
+	csrrs  x0,  0xB8C, x5
  	csrrsi x0,  0xB8C, 0x0a
- 	csrrw  x0,  0xB8C, x0  
+ 	csrrw  x0,  0xB8C, x0
 	csrrwi x0,  0xB8C, 0x0a
 
 	# mhpmcounterh13
 	csrrci x5,  0xB8D, 0x0a
-	csrrc  x5,  0xB8D, x0  
-	csrrc  x0,  0xB8D, x5  
+	csrrc  x5,  0xB8D, x0
+	csrrc  x0,  0xB8D, x5
 	csrrci x5,  0xB8D, 0x0a
-	csrrs  x0,  0xB8D, x5  
+	csrrs  x0,  0xB8D, x5
  	csrrsi x0,  0xB8D, 0x0a
- 	csrrw  x0,  0xB8D, x0  
+ 	csrrw  x0,  0xB8D, x0
 	csrrwi x0,  0xB8D, 0x0a
 
 	# mhpmcounterh14
 	csrrci x5,  0xB8E, 0x0a
-	csrrc  x5,  0xB8E, x0  
-	csrrc  x0,  0xB8E, x5  
+	csrrc  x5,  0xB8E, x0
+	csrrc  x0,  0xB8E, x5
 	csrrci x5,  0xB8E, 0x0a
-	csrrs  x0,  0xB8E, x5  
+	csrrs  x0,  0xB8E, x5
  	csrrsi x0,  0xB8E, 0x0a
- 	csrrw  x0,  0xB8E, x0  
+ 	csrrw  x0,  0xB8E, x0
 	csrrwi x0,  0xB8E, 0x0a
 
 	# mhpmcounterh15
 	csrrci x5,  0xB8F, 0x0a
-	csrrc  x5,  0xB8F, x0  
-	csrrc  x0,  0xB8F, x5  
+	csrrc  x5,  0xB8F, x0
+	csrrc  x0,  0xB8F, x5
 	csrrci x5,  0xB8F, 0x0a
-	csrrs  x0,  0xB8F, x5  
+	csrrs  x0,  0xB8F, x5
  	csrrsi x0,  0xB8F, 0x0a
- 	csrrw  x0,  0xB8F, x0  
+ 	csrrw  x0,  0xB8F, x0
 	csrrwi x0,  0xB8F, 0x0a
 
 	# mhpmcounterh16
 	csrrci x5,  0xB90, 0x0a
-	csrrc  x5,  0xB90, x0  
-	csrrc  x0,  0xB90, x5  
+	csrrc  x5,  0xB90, x0
+	csrrc  x0,  0xB90, x5
 	csrrci x5,  0xB90, 0x0a
-	csrrs  x0,  0xB90, x5  
+	csrrs  x0,  0xB90, x5
  	csrrsi x0,  0xB90, 0x0a
- 	csrrw  x0,  0xB90, x0  
+ 	csrrw  x0,  0xB90, x0
 	csrrwi x0,  0xB90, 0x0a
 
 	# mhpmcounterh17
 	csrrci x5,  0xB91, 0x0a
-	csrrc  x5,  0xB91, x0  
-	csrrc  x0,  0xB91, x5  
+	csrrc  x5,  0xB91, x0
+	csrrc  x0,  0xB91, x5
 	csrrci x5,  0xB91, 0x0a
-	csrrs  x0,  0xB91, x5  
+	csrrs  x0,  0xB91, x5
  	csrrsi x0,  0xB91, 0x0a
- 	csrrw  x0,  0xB91, x0  
+ 	csrrw  x0,  0xB91, x0
 	csrrwi x0,  0xB91, 0x0a
 
 	# mhpmcounterh18
 	csrrci x5,  0xB92, 0x0a
-	csrrc  x5,  0xB92, x0  
-	csrrc  x0,  0xB92, x5  
+	csrrc  x5,  0xB92, x0
+	csrrc  x0,  0xB92, x5
 	csrrci x5,  0xB92, 0x0a
-	csrrs  x0,  0xB92, x5  
+	csrrs  x0,  0xB92, x5
  	csrrsi x0,  0xB92, 0x0a
- 	csrrw  x0,  0xB92, x0  
+ 	csrrw  x0,  0xB92, x0
 	csrrwi x0,  0xB92, 0x0a
 
 	# mhpmcounterh19
 	csrrci x5,  0xB93, 0x0a
-	csrrc  x5,  0xB93, x0  
-	csrrc  x0,  0xB93, x5  
+	csrrc  x5,  0xB93, x0
+	csrrc  x0,  0xB93, x5
 	csrrci x5,  0xB93, 0x0a
-	csrrs  x0,  0xB93, x5  
+	csrrs  x0,  0xB93, x5
  	csrrsi x0,  0xB93, 0x0a
- 	csrrw  x0,  0xB93, x0  
+ 	csrrw  x0,  0xB93, x0
 	csrrwi x0,  0xB93, 0x0a
 
 	# mhpmcounterh20
 	csrrci x5,  0xB94, 0x0a
-	csrrc  x5,  0xB94, x0  
-	csrrc  x0,  0xB94, x5  
+	csrrc  x5,  0xB94, x0
+	csrrc  x0,  0xB94, x5
 	csrrci x5,  0xB94, 0x0a
-	csrrs  x0,  0xB94, x5  
+	csrrs  x0,  0xB94, x5
  	csrrsi x0,  0xB94, 0x0a
- 	csrrw  x0,  0xB94, x0  
+ 	csrrw  x0,  0xB94, x0
 	csrrwi x0,  0xB94, 0x0a
 
 	# mhpmcounterh21
 	csrrci x5,  0xB95, 0x0a
-	csrrc  x5,  0xB95, x0  
-	csrrc  x0,  0xB95, x5  
+	csrrc  x5,  0xB95, x0
+	csrrc  x0,  0xB95, x5
 	csrrci x5,  0xB95, 0x0a
-	csrrs  x0,  0xB95, x5  
+	csrrs  x0,  0xB95, x5
  	csrrsi x0,  0xB95, 0x0a
- 	csrrw  x0,  0xB95, x0  
+ 	csrrw  x0,  0xB95, x0
 	csrrwi x0,  0xB95, 0x0a
 
 	# mhpmcounterh22
 	csrrci x5,  0xB96, 0x0a
-	csrrc  x5,  0xB96, x0  
-	csrrc  x0,  0xB96, x5  
+	csrrc  x5,  0xB96, x0
+	csrrc  x0,  0xB96, x5
 	csrrci x5,  0xB96, 0x0a
-	csrrs  x0,  0xB96, x5  
+	csrrs  x0,  0xB96, x5
  	csrrsi x0,  0xB96, 0x0a
- 	csrrw  x0,  0xB96, x0  
+ 	csrrw  x0,  0xB96, x0
 	csrrwi x0,  0xB96, 0x0a
 
 	# mhpmcounterh23
 	csrrci x5,  0xB97, 0x0a
-	csrrc  x5,  0xB97, x0  
-	csrrc  x0,  0xB97, x5  
+	csrrc  x5,  0xB97, x0
+	csrrc  x0,  0xB97, x5
 	csrrci x5,  0xB97, 0x0a
-	csrrs  x0,  0xB97, x5  
+	csrrs  x0,  0xB97, x5
  	csrrsi x0,  0xB97, 0x0a
- 	csrrw  x0,  0xB97, x0  
+ 	csrrw  x0,  0xB97, x0
 	csrrwi x0,  0xB97, 0x0a
 
 	# mhpmcounterh24
 	csrrci x5,  0xB98, 0x0a
-	csrrc  x5,  0xB98, x0  
-	csrrc  x0,  0xB98, x5  
+	csrrc  x5,  0xB98, x0
+	csrrc  x0,  0xB98, x5
 	csrrci x5,  0xB98, 0x0a
-	csrrs  x0,  0xB98, x5  
+	csrrs  x0,  0xB98, x5
  	csrrsi x0,  0xB98, 0x0a
- 	csrrw  x0,  0xB98, x0  
+ 	csrrw  x0,  0xB98, x0
 	csrrwi x0,  0xB98, 0x0a
 
 	# mhpmcounterh25
 	csrrci x5,  0xB99, 0x0a
-	csrrc  x5,  0xB99, x0  
-	csrrc  x0,  0xB99, x5  
+	csrrc  x5,  0xB99, x0
+	csrrc  x0,  0xB99, x5
 	csrrci x5,  0xB99, 0x0a
-	csrrs  x0,  0xB99, x5  
+	csrrs  x0,  0xB99, x5
  	csrrsi x0,  0xB99, 0x0a
- 	csrrw  x0,  0xB99, x0  
+ 	csrrw  x0,  0xB99, x0
 	csrrwi x0,  0xB99, 0x0a
 
 	# mhpmcounterh26
 	csrrci x5,  0xB9A, 0x0a
-	csrrc  x5,  0xB9A, x0  
-	csrrc  x0,  0xB9A, x5  
+	csrrc  x5,  0xB9A, x0
+	csrrc  x0,  0xB9A, x5
 	csrrci x5,  0xB9A, 0x0a
-	csrrs  x0,  0xB9A, x5  
+	csrrs  x0,  0xB9A, x5
  	csrrsi x0,  0xB9A, 0x0a
- 	csrrw  x0,  0xB9A, x0  
+ 	csrrw  x0,  0xB9A, x0
 	csrrwi x0,  0xB9A, 0x0a
 
 	# mhpmcounterh27
 	csrrci x5,  0xB9B, 0x0a
-	csrrc  x5,  0xB9B, x0  
-	csrrc  x0,  0xB9B, x5  
+	csrrc  x5,  0xB9B, x0
+	csrrc  x0,  0xB9B, x5
 	csrrci x5,  0xB9B, 0x0a
-	csrrs  x0,  0xB9B, x5  
+	csrrs  x0,  0xB9B, x5
  	csrrsi x0,  0xB9B, 0x0a
- 	csrrw  x0,  0xB9B, x0  
+ 	csrrw  x0,  0xB9B, x0
 	csrrwi x0,  0xB9B, 0x0a
 
 	# mhpmcounterh28
 	csrrci x5,  0xB9C, 0x0a
-	csrrc  x5,  0xB9C, x0  
-	csrrc  x0,  0xB9C, x5  
+	csrrc  x5,  0xB9C, x0
+	csrrc  x0,  0xB9C, x5
 	csrrci x5,  0xB9C, 0x0a
-	csrrs  x0,  0xB9C, x5  
+	csrrs  x0,  0xB9C, x5
  	csrrsi x0,  0xB9C, 0x0a
- 	csrrw  x0,  0xB9C, x0  
+ 	csrrw  x0,  0xB9C, x0
 	csrrwi x0,  0xB9C, 0x0a
 
 	# mhpmcounterh29
 	csrrci x5,  0xB9D, 0x0a
-	csrrc  x5,  0xB9D, x0  
-	csrrc  x0,  0xB9D, x5  
+	csrrc  x5,  0xB9D, x0
+	csrrc  x0,  0xB9D, x5
 	csrrci x5,  0xB9D, 0x0a
-	csrrs  x0,  0xB9D, x5  
+	csrrs  x0,  0xB9D, x5
  	csrrsi x0,  0xB9D, 0x0a
- 	csrrw  x0,  0xB9D, x0  
+ 	csrrw  x0,  0xB9D, x0
 	csrrwi x0,  0xB9D, 0x0a
 
 	# mhpmcounterh30
 	csrrci x5,  0xB9E, 0x0a
-	csrrc  x5,  0xB9E, x0  
-	csrrc  x0,  0xB9E, x5  
+	csrrc  x5,  0xB9E, x0
+	csrrc  x0,  0xB9E, x5
 	csrrci x5,  0xB9E, 0x0a
-	csrrs  x0,  0xB9E, x5  
+	csrrs  x0,  0xB9E, x5
  	csrrsi x0,  0xB9E, 0x0a
- 	csrrw  x0,  0xB9E, x0  
+ 	csrrw  x0,  0xB9E, x0
 	csrrwi x0,  0xB9E, 0x0a
 
 	# mhpmcounterh31
 	csrrci x5,  0xB9F, 0x0a
-	csrrc  x5,  0xB9F, x0  
-	csrrc  x0,  0xB9F, x5  
+	csrrc  x5,  0xB9F, x0
+	csrrc  x0,  0xB9F, x5
 	csrrci x5,  0xB9F, 0x0a
-	csrrs  x0,  0xB9F, x5  
+	csrrs  x0,  0xB9F, x5
  	csrrsi x0,  0xB9F, 0x0a
- 	csrrw  x0,  0xB9F, x0  
+ 	csrrw  x0,  0xB9F, x0
 	csrrwi x0,  0xB9F, 0x0a
 
 ###############################################################################
@@ -1004,7 +1010,7 @@ main:
 	csrrwi x0,  3859, 0x0a   # illegal instruction: attempt to write RO CSR
 
 	csrrc  x5,  3859, x0     # not illegal
-	li     x30, 0x00000000
+	li     x30, MIMPID_RESET_VALUE
 	bne    x5,  x30, fail
 
 	# mhartid
@@ -1086,7 +1092,7 @@ u_sw_irq_handler:
     csrrw x0, mepc, x27
     c.addi x31, 1
     mret
-    
+
 _exit:
     j _exit
 

--- a/cv32e40p/tests/programs/custom/mhpmcounter29_csr_access_test_2/mhpmcounter29_csr_access_test_2.S
+++ b/cv32e40p/tests/programs/custom/mhpmcounter29_csr_access_test_2/mhpmcounter29_csr_access_test_2.S
@@ -39,12 +39,24 @@ _start:
 .section .text
 _start_main:
 
-	#ifdef NO_PULP
-	#define EXP_MISA 0x40001104
-	#else
-	#define EXP_MISA 0x40801104
-	#endif
+#define ADD_X(val) ((val) | (1 << 23))
+#define ADD_F(val) ((val) | (1 <<  5))
 
+#define BASE_MISA 0x40001104
+
+#if defined(NO_PULP)
+#define EXP_MISA BASE_MISA
+#else
+  #if defined(PULP) && defined(FPU) && !defined(ZFINX)
+    #define EXP_MISA ADD_X(ADD_F(BASE_MISA))
+  #elif defined(PULP) && defined(FPU) && defined(ZFINX)
+    #define EXP_MISA ADD_X((BASE_MISA))
+  #elif defined(PULP)
+    #define EXP_MISA ADD_X((BASE_MISA))
+  #else
+    #define EXP_MISA BASE_MISA
+  #endif
+#endif
 
 ###############################################################################
 # Script generated code to verify write/read access of these CSRs.

--- a/cv32e40p/tests/programs/custom/modeled_csr_por/modeled_csr_por.c
+++ b/cv32e40p/tests/programs/custom/modeled_csr_por/modeled_csr_por.c
@@ -33,10 +33,23 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#define ADD_X(val) ((val) | (1 << 23))
+#define ADD_F(val) ((val) | (1 <<  5))
+
+#define BASE_MISA 0x40001104
+
 #ifdef NO_PULP
-#define EXP_MISA 0x40001104
+#define EXP_MISA BASE_MISA
 #else
-#define EXP_MISA 0x40801104
+  #if defined(PULP) && defined(FPU) && !defined(ZFINX)
+    #define EXP_MISA ADD_X(ADD_F(BASE_MISA))
+  #elif defined(PULP) && defined(FPU) && defined(ZFINX)
+    #define EXP_MISA ADD_X((BASE_MISA))
+  #elif defined(PULP)
+    #define EXP_MISA ADD_X((BASE_MISA))
+  #else
+    #define EXP_MISA BASE_MISA
+  #endif
 #endif
 
 int main(int argc, char *argv[])

--- a/cv32e40p/tests/programs/custom/requested_csr_por/requested_csr_por.c
+++ b/cv32e40p/tests/programs/custom/requested_csr_por/requested_csr_por.c
@@ -31,10 +31,23 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#define ADD_X(val) ((val) | (1 << 23))
+#define ADD_F(val) ((val) | (1 <<  5))
+
+#define BASE_MISA 0x40001104
+
 #ifdef NO_PULP
-#define EXP_MISA 0x40001104
+#define EXP_MISA BASE_MISA
 #else
-#define EXP_MISA 0x40801104
+  #if defined(PULP) && defined(FPU) && !defined(ZFINX)
+    #define EXP_MISA ADD_X(ADD_F(BASE_MISA))
+  #elif defined(PULP) && defined(FPU) && defined(ZFINX)
+    #define EXP_MISA ADD_X((BASE_MISA))
+  #elif defined(PULP)
+    #define EXP_MISA ADD_X((BASE_MISA))
+  #else
+    #define EXP_MISA BASE_MISA
+  #endif
 #endif
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
This PR is focused on adding a regress file for unused v1 tests in v2 environment. Some tests needed to be adjusted since Xpulp encoding has changed (previous illegal instructions could be totally legal in v2), and changes to CSRs values and behavior (MISA bits depends on the RTL configuration, MSTATUS behavior with FP instructions, ...) 

Commit 4ff8997bb27566a6242c7407a4cf5b4cc162920f contains a bigger update than other tests. 
This test contains tons of generated instructions targeting CSRs and performing basic write/read self-check. Unfortunately, MSTATUS behavior with F extension is far from easy to manually check. Bit 31 is RO **BUT** if bits 14 and 13 are set by a CSR write, bit 31 is automatically set simultaneously. 
I decided to update the behavior for the first occurence of MSTATUS write/read check, but ignore self-check for following occurences. The behaviour is unchanger for non-FPU configurations. 