### PR TITLE
Revert previous udpates because it breaks the hwloop implementation l…

### DIFF
--- a/cv32e40p/env/corev-dv/cv32e40p_rand_instr_stream.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_rand_instr_stream.sv
@@ -66,11 +66,10 @@ class cv32e40p_rand_instr_stream extends riscv_rand_instr_stream;
       bit idx_search_done = 0;
       int rand_cnt = 0;
 
-      do begin 
-        idx = $urandom_range(0, current_instr_cnt-1); 
-      end while (instr_list[idx].atomic);
+      idx = $urandom_range(0, current_instr_cnt-1);
       while (!instr_list[idx].atomic && !idx_search_done) begin
         int idx_e = 0;
+        idx = $urandom_range(0, current_instr_cnt-1);
         idx_e = (idx + new_instr_cnt-1);
 
         if (idx_start.size() == 0) begin : SEARCH_IDX_FOR_NEW_INSTR
@@ -134,10 +133,6 @@ class cv32e40p_rand_instr_stream extends riscv_rand_instr_stream;
           end
           break;
         end // rand_cnt
-
-        do begin 
-          idx = $urandom_range(0, current_instr_cnt-1); 
-        end while (instr_list[idx].atomic);
 
       end // while
 


### PR DESCRIPTION
critical update to revert the updates that breaks hwloop implementation logic in tb.