### PR TITLE
Proposition for a fix

### DIFF
--- a/cv32e40p/tests/programs/corev-dv/corev_rand_illegal_instr_test/corev-dv.yaml
+++ b/cv32e40p/tests/programs/corev-dv/corev_rand_illegal_instr_test/corev-dv.yaml
@@ -4,7 +4,7 @@ description: >
     RISCV-DV generated random instruction test with illegal instructions
 plusargs: >
     +instr_cnt=30000
-    +num_of_sub_program=5
+    +num_of_sub_program=0
     +directed_instr_0=riscv_load_store_rand_instr_stream,4
     +directed_instr_1=riscv_loop_instr,4
     +directed_instr_2=riscv_hazard_instr_stream,4
@@ -14,4 +14,5 @@ plusargs: >
     +directed_instr_6=riscv_jal_instr,4
     +illegal_instr_ratio=10
     +hint_instr_ratio=5
-
+    +test_override_riscv_instr_stream=1
+    +test_override_riscv_instr_sequence=1


### PR DESCRIPTION
For v1, this test was using the base riscv-dv illegal instruction class, that generates X instructions without knowing if X is present or not, and that produces cases where cv.bneimm / cv.beqimm instructions are generated, leading to obvious issues. 

The simplest solution is what I did : use the classes implemented for v2 verification, which translates to using this couple of plusargs to better generate illegal instructions: 

```
+test_override_riscv_instr_stream=1
+test_override_riscv_instr_sequence=1
```

However, the generation is now _not really_ the same that it was for v1... We can approve this and ask Mike his opinion

Also, I saw the plusargs option `num_of_sub_program` is not working for anything other than 0 with our updated classes, so I removed it and we should address a fix for that.


