### PR TITLE
added new parts in the test to access CSR during HWLoops

### DIFF
--- a/cv32e40p/tests/programs/custom/pulp_hardware_loop/pulp_hardware_loop.S
+++ b/cv32e40p/tests/programs/custom/pulp_hardware_loop/pulp_hardware_loop.S
@@ -15,9 +15,9 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
-// 
+//
 // Description : PULP Hardware Loops instructions test
-// 
+//
 
 .globl _start
 .globl main
@@ -312,7 +312,54 @@ test6_4:
     c.addi x15, 0x1
 test6_5:
     csrr x20, 0xCC6
-    beq x20, x10, exit_check
+    beq x20, x10, test7
+    c.addi x15, 0x1
+
+
+# test7 CSR read accesses during HWloop (same as test1 but with CSR reads to misa)
+
+test7:
+    li x5, 0
+    li x6, 0
+    li x7, 0
+    li x8, 0
+    li x17, 0
+    li x18, 0
+
+    .balign 4
+
+    cv.starti 1, startO_7
+    cv.endi 1, endO_7
+    cv.counti 1, 10
+    cv.starti 0, startZ_7
+    cv.endi 0, endZ_7
+startO_7:
+    cv.counti 0, 10
+    csrrw x5, 0x301, x0 # misa
+
+    .option norvc
+
+startZ_7:
+    addi x17, x17, 1
+    csrrw x5, 0x301, x0 # misa
+    addi x17, x17, 1
+    addi x17, x17, 1
+    csrrw x6, 0x301, x0 # misa
+endZ_7:
+    addi x18, x18, 1
+    csrrw x7, 0x301, x0 # misa
+    addi x18, x18, 1
+    csrrw x8, 0x301, x0 # misa
+endO_7:
+
+    .option rvc
+
+    li x20, 300
+    beq x20, x17, test7_1
+    c.addi x15, 0x1
+test7_1:
+    li x21, 20
+    beq x21, x18, exit_check
     c.addi x15, 0x1
 
 exit_check:


### PR DESCRIPTION
This test is failing with coverage enabled only, I push it anyway since the fail appears even with the previous version of the test